### PR TITLE
Made SPD optional

### DIFF
--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd.adjustment/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/adjustment/StepAdjustmentBehavior.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd.adjustment/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/adjustment/StepAdjustmentBehavior.java
@@ -8,6 +8,7 @@ import javax.inject.Inject;
 import org.apache.log4j.Logger;
 import org.palladiosimulator.analyzer.slingshot.behavior.spd.data.ModelAdjusted;
 import org.palladiosimulator.analyzer.slingshot.behavior.spd.data.StepBasedAdjustor;
+import org.palladiosimulator.analyzer.slingshot.common.annotations.Nullable;
 import org.palladiosimulator.analyzer.slingshot.core.extension.SimulationBehaviorExtension;
 import org.palladiosimulator.analyzer.slingshot.eventdriver.annotations.Subscribe;
 import org.palladiosimulator.analyzer.slingshot.eventdriver.annotations.eventcontract.EventCardinality;
@@ -23,9 +24,17 @@ public class StepAdjustmentBehavior extends AbstractAdjustmentExecutor implement
 	
 	private static final Logger LOGGER = Logger.getLogger(StepAdjustmentBehavior.class);
 
+	private final boolean activated;
+	
 	@Inject
-	public StepAdjustmentBehavior(Allocation allocation, MonitorRepository monitorRepository) {
+	public StepAdjustmentBehavior(Allocation allocation, @Nullable MonitorRepository monitorRepository) {
 		super(allocation, monitorRepository);
+		this.activated = monitorRepository != null;
+	}
+	
+	@Override
+	public boolean isActive() {
+		return this.activated;
 	}
 
 	@Subscribe

--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/SpdBehavior.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/SpdBehavior.java
@@ -3,6 +3,7 @@ package org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter;
 import static org.palladiosimulator.analyzer.slingshot.eventdriver.annotations.eventcontract.EventCardinality.MANY;
 
 import javax.inject.Inject;
+import org.palladiosimulator.analyzer.slingshot.common.annotations.Nullable;
 
 import org.apache.log4j.Logger;
 import org.palladiosimulator.analyzer.slingshot.behavior.spd.data.SimulationTimeReached;
@@ -37,9 +38,14 @@ public class SpdBehavior implements SimulationBehaviorExtension {
 	@Inject
 	public SpdBehavior(
 			final SimulationDriver driver,
-			final SPD spdModel) {
+			@Nullable final SPD spdModel) {
 		this.spdModel = spdModel;
 		this.driver = driver;
+	}
+	
+	@Override
+	public boolean isActive() {
+		return this.spdModel != null;
 	}
 
 	@Subscribe

--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/ui/SPDModelConfiguration.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/ui/SPDModelConfiguration.java
@@ -23,6 +23,7 @@ public class SPDModelConfiguration implements SystemBehaviorExtension {
 			 .fileExtensions(FILE_EXTENSIONS)
 			 .modelClass(SPD.class)
 			 .label("Scaling Policy Definition")
+			 .optional(true)
 			 .build();
 	}
 	

--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/ui/SPDModelProvider.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/ui/SPDModelProvider.java
@@ -5,6 +5,7 @@ import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import org.apache.log4j.Logger;
 import org.eclipse.emf.ecore.EObject;
 import org.palladiosimulator.analyzer.slingshot.core.extension.ModelProvider;
 import org.palladiosimulator.analyzer.slingshot.core.extension.PCMResourceSetPartitionProvider;
@@ -13,6 +14,8 @@ import org.palladiosimulator.spd.SpdPackage;
 
 @Singleton
 public class SPDModelProvider implements ModelProvider<SPD> {
+	
+	private static final Logger LOGGER = Logger.getLogger(SPDModelProvider.class);
 
 	private final PCMResourceSetPartitionProvider provider;
 	
@@ -25,7 +28,10 @@ public class SPDModelProvider implements ModelProvider<SPD> {
 	public SPD get() {
 		final List<EObject> spds = provider.get().getElement(SpdPackage.eINSTANCE.getSPD());
 		if (spds.size() == 0) {
-			throw new IllegalStateException("Monitor not present: List size is 0.");
+			// It is important that for optional model, the corresponding classes using the model
+			// should be able to handle nullable!
+			LOGGER.warn("An SPD model was not provided. Null will be returned");
+			return null;
 		}
 		return (SPD) spds.get(0);
 	}


### PR DESCRIPTION
Made SPD optional.

Before, it was not possible to start a simulation without an SPD file. Now, it is possible.

Resolves #2 