### PR TITLE
Task count trigger

### DIFF
--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/ScalingTriggerInterpreter.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/ScalingTriggerInterpreter.java
@@ -187,7 +187,7 @@ public class ScalingTriggerInterpreter extends TriggersSwitch<ScalingTriggerInte
 																	  .name("cpuUtilizationMade"))
 											   .triggerChecker(new CPUUtilizationTriggerChecker(
 													   				   this.trigger, 
-																	   object.getAggregationOverElements(), 
+																	   object, 
 																	   policy.getTargetGroup())
 													   		  );
 		}

--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/SpdInterpreter.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/SpdInterpreter.java
@@ -40,6 +40,7 @@ class SpdInterpreter extends SpdSwitch<SpdInterpreter.InterpretationResult> {
 		if (!policy.isActive()) {
 			return new InterpretationResult();
 		}
+		
 		final ScalingTriggerInterpreter.InterpretationResult intrResult = (new ScalingTriggerInterpreter(policy)).doSwitch(policy.getScalingTrigger());
 		return (new InterpretationResult())
 				.adjustorContext(new SPDAdjustorContext(policy, intrResult.getTriggerChecker(), intrResult.getEventsToListen()))

--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/StimuliInterpreter.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/StimuliInterpreter.java
@@ -1,0 +1,95 @@
+package org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter;
+
+import org.palladiosimulator.analyzer.slingshot.behavior.spd.data.SimulationTimeReached;
+import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.ScalingTriggerInterpreter.InterpretationResult;
+import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entity.trigger.CPUUtilizationTriggerChecker;
+import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entity.trigger.OperationResponseTimeTriggerChecker;
+import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entity.trigger.SimulationTimeChecker;
+import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entity.trigger.TaskCountTriggerChecker;
+import org.palladiosimulator.analyzer.slingshot.eventdriver.entity.Subscriber;
+import org.palladiosimulator.analyzer.slingshot.monitor.data.events.MeasurementMade;
+import org.palladiosimulator.spd.triggers.SimpleFireOnValue;
+import org.palladiosimulator.spd.triggers.expectations.ExpectedCount;
+import org.palladiosimulator.spd.triggers.expectations.ExpectedPercentage;
+import org.palladiosimulator.spd.triggers.expectations.ExpectedTime;
+import org.palladiosimulator.spd.triggers.expectations.ExpectedValue;
+import org.palladiosimulator.spd.triggers.stimuli.CPUUtilization;
+import org.palladiosimulator.spd.triggers.stimuli.OperationResponseTime;
+import org.palladiosimulator.spd.triggers.stimuli.SimulationTime;
+import org.palladiosimulator.spd.triggers.stimuli.TaskCount;
+import org.palladiosimulator.spd.triggers.stimuli.util.StimuliSwitch;
+
+import com.google.common.base.Preconditions;
+
+final class StimuliInterpreter extends StimuliSwitch<InterpretationResult> {
+
+	private final ScalingTriggerInterpreter scalingTriggerInterpreter;
+	private final SimpleFireOnValue trigger;
+
+	public StimuliInterpreter(final ScalingTriggerInterpreter scalingTriggerInterpreter, final SimpleFireOnValue trigger) {
+		super();
+		this.scalingTriggerInterpreter = scalingTriggerInterpreter;
+		this.trigger = trigger;
+	}
+
+
+
+	@Override
+	public InterpretationResult caseSimulationTime(final SimulationTime object) {
+		final ExpectedTime expectedTime = this.checkExpectedValue(ExpectedTime.class);
+
+		final SimulationTimeReached event = new SimulationTimeReached(this.scalingTriggerInterpreter.policy.getTargetGroup().getId(), expectedTime.getValue());
+
+		return (new InterpretationResult()).scheduleEvent(event)
+										   .listenEvent(Subscriber.builder(SimulationTimeReached.class)
+												   				  .name("something"))
+										   .triggerChecker(new SimulationTimeChecker(this.trigger));
+	}
+
+
+
+	@Override
+	public InterpretationResult caseOperationResponseTime(final OperationResponseTime object) {
+		this.checkExpectedValue(ExpectedTime.class);
+		return (new InterpretationResult()).listenEvent(Subscriber.builder(MeasurementMade.class)
+																  .name("measurementMade"))
+									       .triggerChecker(new OperationResponseTimeTriggerChecker(this.trigger));
+	}
+	
+	@Override
+	public InterpretationResult caseCPUUtilization(final CPUUtilization object) {
+		final ExpectedPercentage expectedPercentage = this.checkExpectedValue(ExpectedPercentage.class);
+		Preconditions.checkArgument(0 <= expectedPercentage.getValue() && expectedPercentage.getValue() <= 100, 
+									"The expected percentage must be between 0 and 100");
+		
+		
+		return (new InterpretationResult()).listenEvent(Subscriber.builder(MeasurementMade.class)
+																  .name("cpuUtilizationMade"))
+										   .triggerChecker(new CPUUtilizationTriggerChecker(
+												   				   this.trigger, 
+																   object, 
+																   this.scalingTriggerInterpreter.policy.getTargetGroup())
+												   		  );
+	}
+
+	@Override
+	public InterpretationResult caseTaskCount(final TaskCount object) {
+		this.checkExpectedValue(ExpectedCount.class);
+		
+		return (new InterpretationResult()).listenEvent(Subscriber.builder(MeasurementMade.class)
+																  .name("taskCount"))
+										   .triggerChecker(new TaskCountTriggerChecker(this.trigger, object, this.scalingTriggerInterpreter.policy.getTargetGroup()));
+	}
+
+	@SuppressWarnings("unchecked")
+	private <T extends ExpectedValue> T checkExpectedValue(final Class<T> expectedType) {
+		if (!(expectedType.isAssignableFrom(this.trigger.getExpectedValue().getClass()))) {
+			throw new IllegalArgumentException(String.format("It is only possible "
+					+ "that the trigger is of type %s, but the given type was %s",
+					expectedType.getSimpleName(),
+					this.trigger.getExpectedValue().getClass().getSimpleName()));
+		}
+		
+		return (T) this.trigger.getExpectedValue();
+	}
+}

--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/aggregator/AbstractWindowAggregation.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/aggregator/AbstractWindowAggregation.java
@@ -3,6 +3,8 @@ package org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entity
 import java.util.ArrayDeque;
 import java.util.Queue;
 
+import org.palladiosimulator.spd.triggers.AGGREGATIONMETHOD;
+
 /**
  * A window-based aggregator with a window size of the last
  * {@code windowSize} measurements.
@@ -10,6 +12,8 @@ import java.util.Queue;
  * @author Julijan Katic
  */
 public abstract class AbstractWindowAggregation {
+	
+	public static final int DEFAULT_WINDOW_SIZE = 10;
 
 	protected final int windowSize;
 	protected final Queue<Double> valuesToConsider;
@@ -66,5 +70,20 @@ public abstract class AbstractWindowAggregation {
 	
 	public final double getCurrentValue() {
 		return this.currentValue;
+	}
+	
+	public static AbstractWindowAggregation getFromAggregationMethod(final AGGREGATIONMETHOD aggregationMethod, final int windowSize) {
+		return switch (aggregationMethod) {
+			case MIN -> new MinWindowAggregation(windowSize);
+			case AVERAGE -> new MeanWindowAggregation(windowSize);
+			case MAX -> new MaxWindowAggregation(windowSize);
+			case MEDIAN -> new MedianWindowAggregation(windowSize);
+			case SUM -> new SumWindowAggregation(windowSize);
+			default -> throw new IllegalArgumentException("Unexpected value: " + aggregationMethod);
+		};
+	}
+	
+	public static AbstractWindowAggregation getFromAggregationMethod(final AGGREGATIONMETHOD aggregationMethod) {
+		return getFromAggregationMethod(aggregationMethod, DEFAULT_WINDOW_SIZE);
 	}
 }

--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/targetgroup/TargetGroupChecker.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/targetgroup/TargetGroupChecker.java
@@ -1,89 +1,42 @@
 package org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entity.targetgroup;
 
 import java.util.Objects;
+
 import org.palladiosimulator.analyzer.slingshot.behavior.spd.data.SimulationTimeReached;
 import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entities.Filter;
 import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entities.FilterObjectWrapper;
 import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entities.FilterResult;
+import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.utils.MeasuringPointInsideTargetGroup;
 import org.palladiosimulator.analyzer.slingshot.common.events.DESEvent;
 import org.palladiosimulator.analyzer.slingshot.monitor.data.events.MeasurementMade;
-import org.palladiosimulator.edp2.models.measuringpoint.MeasuringPoint;
-import org.palladiosimulator.pcmmeasuringpoint.ActiveResourceMeasuringPoint;
-import org.palladiosimulator.pcmmeasuringpoint.AssemblyReference;
-import org.palladiosimulator.pcmmeasuringpoint.ResourceContainerMeasuringPoint;
-import org.palladiosimulator.pcmmeasuringpoint.ResourceEnvironmentMeasuringPoint;
-import org.palladiosimulator.spd.targets.ElasticInfrastructure;
-import org.palladiosimulator.spd.targets.ServiceGroup;
 import org.palladiosimulator.spd.targets.TargetGroup;
 
 public class TargetGroupChecker implements Filter {
 
 	private final TargetGroup targetGroup;
+	private final MeasuringPointInsideTargetGroup measuringPointInsideTargetGroupSwitch;
 	
 	public TargetGroupChecker(final TargetGroup targetGroup) {
 		this.targetGroup = Objects.requireNonNull(targetGroup);
+		this.measuringPointInsideTargetGroupSwitch = new MeasuringPointInsideTargetGroup(targetGroup);
 	}
 	
 	@Override
 	public FilterResult doProcess(final FilterObjectWrapper objectWrapper) {
 		final DESEvent event = objectWrapper.getEventToFilter();
-		if (event instanceof MeasurementMade) {
-			if (this.isInsideTargetGroup((MeasurementMade) event)) {
+		if (event instanceof final MeasurementMade mm) {
+			if (this.measuringPointInsideTargetGroupSwitch.doSwitch(mm.getEntity().getMeasuringPoint())) {
 				return FilterResult.success(event);
-			} else {
-				return FilterResult.disregard("The measurement is not inside this target group");
 			}
-		} else if (event instanceof SimulationTimeReached) {
-			final SimulationTimeReached simulationTimeReached = (SimulationTimeReached) event;
-			if (simulationTimeReached.getTargetGroupId().equals(targetGroup.getId())) {
-				return FilterResult.success(event);
-			} else {
-				return FilterResult.disregard("The target group does not match the event.");
-			}
-		} else {
+			return FilterResult.disregard("The measurement is not inside this target group");
+		}
+		if (!(event instanceof SimulationTimeReached)) {
 			return FilterResult.disregard("The event can only be checked if it is a MeasurementMade OR SimulationTimeReached at the moment.");
 		}
-	}
-
-	/**
-	 * Checks whether the measuring point of the event is somewhere inside the
-	 * target group (or is the target group itself).
-	 * 
-	 * For ElasticInfrastructure, the measuring points to consider are
-	 *  - ResourceEnvironmentMeasuringPoint
-	 *  - ResourceContainerMeauringPoint
-	 *  - ActiveResourceMeasuringPoint
-	 * 
-	 * For ServiceGroups, the measuring points to consider are all the measuring points
-	 * that extend the {@link AssemblyReference} interface, such as
-	 *   - AssemblyOperationMeasuringPoint
-	 *   - AssemblyPassiveResourceMeasuringPoint
-	 *   - ...
-	 * 
-	 * @param measurementMade The event
-	 * @return true iff the measurement made was somewhere inside the target group.
-	 */
-	private boolean isInsideTargetGroup(final MeasurementMade measurementMade) {
-		final MeasuringPoint measuringPoint = measurementMade.getEntity().getMeasuringPoint();
-		
-		boolean result = false;
-		if (targetGroup instanceof final ElasticInfrastructure ei) {
-			if (measuringPoint instanceof final ResourceEnvironmentMeasuringPoint remp) {
-				result = remp.getResourceEnvironment().equals(ei.getPCM_ResourceEnvironment());
-			} else if (measuringPoint instanceof final ResourceContainerMeasuringPoint rcmp) {
-				result = ei.getPCM_ResourceEnvironment().getResourceContainer_ResourceEnvironment().stream()
-								.anyMatch(container -> container.getId().equals(rcmp.getResourceContainer().getId()));
-			} else if (measuringPoint instanceof final ActiveResourceMeasuringPoint armp) {
-				result = ei.getPCM_ResourceEnvironment().getResourceContainer_ResourceEnvironment().stream()
-								.flatMap(container -> container.getActiveResourceSpecifications_ResourceContainer().stream())
-								.anyMatch(spec -> spec.getId().equals(armp.getActiveResource().getId()));
-			}
-		} else if (targetGroup instanceof final ServiceGroup sg) {
-			if (measuringPoint instanceof final AssemblyReference ar) {
-				result = ar.getAssembly().getId().equals(sg.getUnitAssembly().getId());
-			}
+		final SimulationTimeReached simulationTimeReached = (SimulationTimeReached) event;
+		if (simulationTimeReached.getTargetGroupId().equals(targetGroup.getId())) {
+			return FilterResult.success(event);
 		}
-		
-		return result;
+		return FilterResult.disregard("The target group does not match the event.");
 	}
 }

--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/trigger/AbstractManagedElementTriggerChecker.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/trigger/AbstractManagedElementTriggerChecker.java
@@ -8,6 +8,7 @@ import javax.measure.quantity.Dimensionless;
 import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entities.FilterObjectWrapper;
 import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entities.FilterResult;
 import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entity.aggregator.FixedLengthWindowAggregation;
+import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entity.targetgroup.TargetGroupChecker;
 import org.palladiosimulator.analyzer.slingshot.common.events.DESEvent;
 import org.palladiosimulator.analyzer.slingshot.monitor.data.entities.SlingshotMeasuringValue;
 import org.palladiosimulator.analyzer.slingshot.monitor.data.events.MeasurementMade;
@@ -20,13 +21,16 @@ import org.palladiosimulator.spd.triggers.expectations.ExpectedPrimitive;
 import org.palladiosimulator.spd.triggers.stimuli.ManagedElementsStateStimulus;
 
 /**
- * This abstract class implements the base functionality for {@link ManagedElementsStateStimulus} elements. Measurements
- * for this elements need to be aggregated first, which is done by {@link #aggregateMeasurement(MeasurementMade, MeasuringPoint)}.
- * Afterwards, {@link #getResult(DESEvent)} checks whether enough measurements were made, and whether the calculated value
- * triggers the policy.
+ * This abstract class implements the base functionality for
+ * {@link ManagedElementsStateStimulus} elements. Measurements for this elements
+ * need to be aggregated first, which is done by
+ * {@link #aggregateMeasurement(MeasurementMade, MeasuringPoint)}. Afterwards,
+ * {@link #getResult(DESEvent)} checks whether enough measurements were made,
+ * and whether the calculated value triggers the policy.
  * 
- * Classes that extend this checker need to implement {@link #isMeasuringPointInTargetGroup(MeasuringPoint)}, since each
- * measuring point has a different way of retrieving the right Resource container.
+ * The precondition is that the measuring point, where the measurements are
+ * coming from, are inside the target group. This is done in the
+ * {@link TargetGroupChecker} filter, that should be placed before this filter.
  * 
  * @author Julijan Katic
  *

--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/trigger/AbstractManagedElementTriggerChecker.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/trigger/AbstractManagedElementTriggerChecker.java
@@ -7,7 +7,7 @@ import javax.measure.quantity.Dimensionless;
 
 import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entities.FilterObjectWrapper;
 import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entities.FilterResult;
-import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entity.aggregator.AbstractWindowAggregation;
+import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entity.aggregator.FixedLengthWindowAggregation;
 import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.utils.TargetGroupUtils;
 import org.palladiosimulator.analyzer.slingshot.common.events.DESEvent;
 import org.palladiosimulator.analyzer.slingshot.monitor.data.entities.SlingshotMeasuringValue;
@@ -30,7 +30,7 @@ public abstract class AbstractManagedElementTriggerChecker<T extends ManagedElem
 	protected final T managedElementsStateStimulus;
 	protected final MetricSetDescription metricSetDescription;
 	protected final BaseMetricDescription baseMetricDescription;
-	protected final AbstractWindowAggregation aggregator;
+	protected final FixedLengthWindowAggregation aggregator;
 	protected final Class<MP> measuringPointType;
 	
 	public AbstractManagedElementTriggerChecker(final BaseTrigger trigger, 
@@ -46,7 +46,7 @@ public abstract class AbstractManagedElementTriggerChecker<T extends ManagedElem
 		this.managedElementsStateStimulus = stimulus;
 		this.metricSetDescription = metricSetDescription;
 		this.baseMetricDescription = baseMetricDescription;
-		this.aggregator = AbstractWindowAggregation.getFromAggregationMethod(stimulus.getAggregationOverElements());
+		this.aggregator = FixedLengthWindowAggregation.getFromAggregationMethod(stimulus.getAggregationOverElements());
 		this.measuringPointType = measuringPointType;
 	}
 

--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/trigger/AbstractManagedElementTriggerChecker.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/trigger/AbstractManagedElementTriggerChecker.java
@@ -1,0 +1,111 @@
+package org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entity.trigger;
+
+import java.util.Set;
+
+import javax.measure.Measure;
+import javax.measure.quantity.Dimensionless;
+
+import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entities.FilterObjectWrapper;
+import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entities.FilterResult;
+import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entity.aggregator.AbstractWindowAggregation;
+import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.utils.TargetGroupUtils;
+import org.palladiosimulator.analyzer.slingshot.common.events.DESEvent;
+import org.palladiosimulator.analyzer.slingshot.monitor.data.entities.SlingshotMeasuringValue;
+import org.palladiosimulator.analyzer.slingshot.monitor.data.events.MeasurementMade;
+import org.palladiosimulator.edp2.models.measuringpoint.MeasuringPoint;
+import org.palladiosimulator.metricspec.BaseMetricDescription;
+import org.palladiosimulator.metricspec.MetricSetDescription;
+import org.palladiosimulator.metricspec.constants.MetricDescriptionConstants;
+import org.palladiosimulator.pcm.resourceenvironment.ProcessingResourceSpecification;
+import org.palladiosimulator.pcm.resourceenvironment.ResourceContainer;
+import org.palladiosimulator.pcmmeasuringpoint.ActiveResourceMeasuringPoint;
+import org.palladiosimulator.spd.targets.TargetGroup;
+import org.palladiosimulator.spd.triggers.BaseTrigger;
+import org.palladiosimulator.spd.triggers.expectations.ExpectedPrimitive;
+import org.palladiosimulator.spd.triggers.stimuli.ManagedElementsStateStimulus;
+
+public abstract class AbstractManagedElementTriggerChecker<T extends ManagedElementsStateStimulus, MP extends MeasuringPoint> extends TriggerChecker<T> {
+	
+	protected final TargetGroup targetGroup;
+	protected final T managedElementsStateStimulus;
+	protected final MetricSetDescription metricSetDescription;
+	protected final BaseMetricDescription baseMetricDescription;
+	protected final AbstractWindowAggregation aggregator;
+	protected final Class<MP> measuringPointType;
+	
+	public AbstractManagedElementTriggerChecker(final BaseTrigger trigger, 
+												final T stimulus,
+												final Class<MP> measuringPointType,
+												final TargetGroup targetGroup,
+												final Set<Class<? extends ExpectedPrimitive>> allowedExpectedPrimitives,
+												final MetricSetDescription metricSetDescription,
+												final BaseMetricDescription baseMetricDescription) {
+		super(trigger, (Class<T>) stimulus.getClass(), allowedExpectedPrimitives);
+		
+		this.targetGroup = targetGroup;
+		this.managedElementsStateStimulus = stimulus;
+		this.metricSetDescription = metricSetDescription;
+		this.baseMetricDescription = baseMetricDescription;
+		this.aggregator = AbstractWindowAggregation.getFromAggregationMethod(stimulus.getAggregationOverElements());
+		this.measuringPointType = measuringPointType;
+	}
+
+	@Override
+	public FilterResult doProcess(FilterObjectWrapper event) {
+		if (event.getEventToFilter() instanceof final MeasurementMade measurementMade) {
+			final MeasuringPoint measuringPoint = measurementMade.getEntity().getMeasuringPoint();
+			if (measuringPointType.isAssignableFrom(measuringPoint.getClass())) {
+				/*
+				 * Check that the measuring point points to one of the resource container's
+				 * specifications, and count them only once!
+				 */
+				aggregateMeasurement(measurementMade, measuringPointType.cast(measuringPoint));
+
+
+				/*
+				 * If all the values are collected, then check whether the expected percentage
+				 * matches, otherwise disregard.
+				 */
+				return getResult(measurementMade);
+			}
+		}
+
+
+		return FilterResult.disregard("");
+	}
+
+	/**
+	 * Helper method to retrieve the filter result. If the aggregated value is in
+	 * accordance with the specified trigger, success is returned. If not all
+	 * measurements were made yet, or if the value was not in accordance, then
+	 * disregard.
+	 */
+	protected FilterResult getResult(final DESEvent event) {
+		final double aggregatedValue = this.aggregator.getCurrentValue();
+		if (this.compareToTrigger(aggregatedValue) == ComparatorResult.IN_ACCORDANCE) {
+			return FilterResult.success(event);
+		}
+		return FilterResult.disregard();
+	}
+
+	/*
+	 * Keep history of last n measurements.
+	 */
+	/**
+	 * Helper method to aggregate the measurement in case if the measurement comes from one of the resource containers in the target group.
+	 */
+	protected void aggregateMeasurement(final MeasurementMade measurementMade, final MP measuringPoint) {
+		if (this.isMeasuringPointInTargetGroup(measuringPoint)
+				&& measurementMade.getEntity().getMetricDesciption().getId().equals(this.metricSetDescription.getId())) {
+			aggregator.aggregate(this.getValueForAggregation(measurementMade.getEntity()));
+		}
+	}
+	
+	protected double getValueForAggregation(final SlingshotMeasuringValue smv) {
+		final Measure<Double, Dimensionless> measure = smv.getMeasureForMetric(this.baseMetricDescription);
+		final double value = measure.getValue();
+		return value;
+	}
+	
+	protected abstract boolean isMeasuringPointInTargetGroup(final MP measuringPoint);
+}

--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/trigger/AbstractManagedElementTriggerChecker.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/trigger/AbstractManagedElementTriggerChecker.java
@@ -8,22 +8,31 @@ import javax.measure.quantity.Dimensionless;
 import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entities.FilterObjectWrapper;
 import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entities.FilterResult;
 import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entity.aggregator.FixedLengthWindowAggregation;
-import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.utils.TargetGroupUtils;
 import org.palladiosimulator.analyzer.slingshot.common.events.DESEvent;
 import org.palladiosimulator.analyzer.slingshot.monitor.data.entities.SlingshotMeasuringValue;
 import org.palladiosimulator.analyzer.slingshot.monitor.data.events.MeasurementMade;
 import org.palladiosimulator.edp2.models.measuringpoint.MeasuringPoint;
 import org.palladiosimulator.metricspec.BaseMetricDescription;
 import org.palladiosimulator.metricspec.MetricSetDescription;
-import org.palladiosimulator.metricspec.constants.MetricDescriptionConstants;
-import org.palladiosimulator.pcm.resourceenvironment.ProcessingResourceSpecification;
-import org.palladiosimulator.pcm.resourceenvironment.ResourceContainer;
-import org.palladiosimulator.pcmmeasuringpoint.ActiveResourceMeasuringPoint;
 import org.palladiosimulator.spd.targets.TargetGroup;
 import org.palladiosimulator.spd.triggers.BaseTrigger;
 import org.palladiosimulator.spd.triggers.expectations.ExpectedPrimitive;
 import org.palladiosimulator.spd.triggers.stimuli.ManagedElementsStateStimulus;
 
+/**
+ * This abstract class implements the base functionality for {@link ManagedElementsStateStimulus} elements. Measurements
+ * for this elements need to be aggregated first, which is done by {@link #aggregateMeasurement(MeasurementMade, MeasuringPoint)}.
+ * Afterwards, {@link #getResult(DESEvent)} checks whether enough measurements were made, and whether the calculated value
+ * triggers the policy.
+ * 
+ * Classes that extend this checker need to implement {@link #isMeasuringPointInTargetGroup(MeasuringPoint)}, since each
+ * measuring point has a different way of retrieving the right Resource container.
+ * 
+ * @author Julijan Katic
+ *
+ * @param <T> The concrete element the class is checking for.
+ * @param <MP> The concrete measuring point the checker needs to listen to.
+ */
 public abstract class AbstractManagedElementTriggerChecker<T extends ManagedElementsStateStimulus, MP extends MeasuringPoint> extends TriggerChecker<T> {
 	
 	protected final TargetGroup targetGroup;
@@ -33,6 +42,7 @@ public abstract class AbstractManagedElementTriggerChecker<T extends ManagedElem
 	protected final FixedLengthWindowAggregation aggregator;
 	protected final Class<MP> measuringPointType;
 	
+	@SuppressWarnings("unchecked")
 	public AbstractManagedElementTriggerChecker(final BaseTrigger trigger, 
 												final T stimulus,
 												final Class<MP> measuringPointType,
@@ -81,6 +91,10 @@ public abstract class AbstractManagedElementTriggerChecker<T extends ManagedElem
 	 * disregard.
 	 */
 	protected FilterResult getResult(final DESEvent event) {
+		if (!this.aggregator.isWindowFull()) {
+			return FilterResult.disregard("There are not enough values yet to aggregate.");
+		}
+		
 		final double aggregatedValue = this.aggregator.getCurrentValue();
 		if (this.compareToTrigger(aggregatedValue) == ComparatorResult.IN_ACCORDANCE) {
 			return FilterResult.success(event);
@@ -88,11 +102,9 @@ public abstract class AbstractManagedElementTriggerChecker<T extends ManagedElem
 		return FilterResult.disregard();
 	}
 
-	/*
-	 * Keep history of last n measurements.
-	 */
 	/**
-	 * Helper method to aggregate the measurement in case if the measurement comes from one of the resource containers in the target group.
+	 * Helper method to aggregate the measurement in case if the measurement comes 
+	 * from one of the resource containers in the target group.
 	 */
 	protected void aggregateMeasurement(final MeasurementMade measurementMade, final MP measuringPoint) {
 		if (this.isMeasuringPointInTargetGroup(measuringPoint)
@@ -107,5 +119,15 @@ public abstract class AbstractManagedElementTriggerChecker<T extends ManagedElem
 		return value;
 	}
 	
+	/**
+	 * Checks whether the measuring point is somewhere in the target group and thus, whether
+	 * its measurements are relevant for this trigger. Since each measuring point has a
+	 * different way of retrieving such information, it has to be implemented by the concrete
+	 * trigger.
+	 * 
+	 * @param measuringPoint The measuring point to check.
+	 * @return true if the measuring point lies somewhere in the target group, i.e.
+	 * 		   is relevant for this trigger.
+	 */
 	protected abstract boolean isMeasuringPointInTargetGroup(final MP measuringPoint);
 }

--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/trigger/CPUUtilizationTriggerChecker.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/trigger/CPUUtilizationTriggerChecker.java
@@ -2,28 +2,12 @@ package org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entity
 
 import java.util.Set;
 
-import javax.measure.Measure;
-import javax.measure.quantity.Dimensionless;
-
-import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entities.FilterObjectWrapper;
-import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entities.FilterResult;
-import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entity.aggregator.FixedLengthWindowAggregation;
-import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entity.aggregator.MaxWindowAggregation;
-import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entity.aggregator.MeanWindowAggregation;
-import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entity.aggregator.MedianWindowAggregation;
-import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entity.aggregator.MinWindowAggregation;
-import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entity.aggregator.SumWindowAggregation;
 import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.utils.TargetGroupUtils;
-import org.palladiosimulator.analyzer.slingshot.common.events.DESEvent;
-import org.palladiosimulator.analyzer.slingshot.monitor.data.events.MeasurementMade;
-import org.palladiosimulator.edp2.models.measuringpoint.MeasuringPoint;
 import org.palladiosimulator.metricspec.constants.MetricDescriptionConstants;
 import org.palladiosimulator.pcm.resourceenvironment.ProcessingResourceSpecification;
 import org.palladiosimulator.pcmmeasuringpoint.ActiveResourceMeasuringPoint;
 import org.palladiosimulator.spd.targets.TargetGroup;
-import org.palladiosimulator.spd.triggers.AGGREGATIONMETHOD;
 import org.palladiosimulator.spd.triggers.SimpleFireOnValue;
-import org.palladiosimulator.spd.triggers.expectations.ExpectedCount;
 import org.palladiosimulator.spd.triggers.expectations.ExpectedPercentage;
 import org.palladiosimulator.spd.triggers.stimuli.CPUUtilization;
 
@@ -40,70 +24,6 @@ public class CPUUtilizationTriggerChecker extends AbstractManagedElementTriggerC
 				MetricDescriptionConstants.UTILIZATION_OF_ACTIVE_RESOURCE_TUPLE,
 				MetricDescriptionConstants.UTILIZATION_OF_ACTIVE_RESOURCE);
 	}
-
-//	@Override
-//	public FilterResult doProcess(final FilterObjectWrapper object) {
-//		final DESEvent event = object.getEventToFilter();
-//		if (event instanceof final MeasurementMade measurementMade) {
-//			final MeasuringPoint measuringPoint = measurementMade.getEntity().getMeasuringPoint();
-//			if (measuringPoint instanceof final ActiveResourceMeasuringPoint activeResourceMP) {
-//				/*
-//				 * Check that the measuring point points to one of the resource container's
-//				 * specifications, and count them only once!
-//				 */
-//				aggregateMeasurement(measurementMade, activeResourceMP);
-//
-//
-//				/*
-//				 * If all the values are collected, then check whether the expected percentage
-//				 * matches, otherwise disregard.
-//				 */
-//				return getResult(event);
-//			}
-//		}
-//
-//
-//		return FilterResult.disregard("");
-//	}
-
-	/**
-	 * Helper method to retrieve the filter result. If the aggregated value is in
-	 * accordance with the specified trigger, success is returned. If not all
-	 * measurements were made yet, or if the value was not in accordance, then
-	 * disregard.
-	 */
-	/*
-	private FilterResult getResult(final DESEvent event) {
-		if (!this.aggregator.isWindowFull()) {
-			return FilterResult.disregard("The window for this trigger is not full yet.");
-		}
-		
-		final double aggregatedValue = this.aggregator.getCurrentValue();
-		if (this.compareToTrigger(aggregatedValue) == ComparatorResult.IN_ACCORDANCE) {
-			return FilterResult.success(event);
-		}
-		return FilterResult.disregard();
-	}*/
-
-	/*
-	 * Keep history of last n measurements.
-	 */
-	/**
-	 * Helper method to aggregate the measurement in case if the measurement comes from one of the resource containers in the target group.
-	 */
-	/*private void aggregateMeasurement(final MeasurementMade measurementMade, final ActiveResourceMeasuringPoint activeResourceMP) {
-		final ProcessingResourceSpecification spec = activeResourceMP.getActiveResource();
-		if (TargetGroupUtils.isContainerInTargetGroup(spec.getResourceContainer_ProcessingResourceSpecification(),
-				this.targetGroup)
-				&& measurementMade.getEntity().getMetricDesciption().getId()
-						.equals(MetricDescriptionConstants.UTILIZATION_OF_ACTIVE_RESOURCE_TUPLE.getId())) {
-			final Measure<Double, Dimensionless> measure
-					= measurementMade.getEntity()
-							.getMeasureForMetric(MetricDescriptionConstants.UTILIZATION_OF_ACTIVE_RESOURCE);
-			final double value = measure.getValue();
-			aggregator.aggregate(value);
-		}
-	}*/
 	
 	@Override
 	protected boolean isMeasuringPointInTargetGroup(final ActiveResourceMeasuringPoint activeResourceMP) {

--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/trigger/CPUUtilizationTriggerChecker.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/trigger/CPUUtilizationTriggerChecker.java
@@ -2,32 +2,23 @@ package org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entity
 
 import java.util.Set;
 
-import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.utils.TargetGroupUtils;
 import org.palladiosimulator.metricspec.constants.MetricDescriptionConstants;
-import org.palladiosimulator.pcm.resourceenvironment.ProcessingResourceSpecification;
-import org.palladiosimulator.pcmmeasuringpoint.ActiveResourceMeasuringPoint;
 import org.palladiosimulator.spd.targets.TargetGroup;
 import org.palladiosimulator.spd.triggers.SimpleFireOnValue;
 import org.palladiosimulator.spd.triggers.expectations.ExpectedPercentage;
 import org.palladiosimulator.spd.triggers.stimuli.CPUUtilization;
 
-public class CPUUtilizationTriggerChecker extends AbstractManagedElementTriggerChecker<CPUUtilization, ActiveResourceMeasuringPoint> {
+public class CPUUtilizationTriggerChecker extends AbstractManagedElementTriggerChecker<CPUUtilization> {
 
 	public CPUUtilizationTriggerChecker(final SimpleFireOnValue trigger,
 										final CPUUtilization stimulus,
 								 		final TargetGroup targetGroup) {
 		super(trigger, 
 				stimulus, 
-				ActiveResourceMeasuringPoint.class, 
 				targetGroup,
 				Set.of(ExpectedPercentage.class),
 				MetricDescriptionConstants.UTILIZATION_OF_ACTIVE_RESOURCE_TUPLE,
 				MetricDescriptionConstants.UTILIZATION_OF_ACTIVE_RESOURCE);
 	}
-	
-	@Override
-	protected boolean isMeasuringPointInTargetGroup(final ActiveResourceMeasuringPoint activeResourceMP) {
-		final ProcessingResourceSpecification spec = activeResourceMP.getActiveResource();
-		return TargetGroupUtils.isContainerInTargetGroup(spec.getResourceContainer_ProcessingResourceSpecification(), targetGroup);
-	}
+
 }

--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/trigger/TaskCountTriggerChecker.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/trigger/TaskCountTriggerChecker.java
@@ -1,0 +1,42 @@
+package org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entity.trigger;
+
+import java.util.Set;
+
+import javax.measure.Measure;
+import javax.measure.quantity.Dimensionless;
+
+import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.utils.TargetGroupUtils;
+import org.palladiosimulator.analyzer.slingshot.monitor.data.entities.SlingshotMeasuringValue;
+import org.palladiosimulator.metricspec.constants.MetricDescriptionConstants;
+import org.palladiosimulator.pcm.resourceenvironment.ProcessingResourceSpecification;
+import org.palladiosimulator.pcmmeasuringpoint.ActiveResourceMeasuringPoint;
+import org.palladiosimulator.spd.targets.TargetGroup;
+import org.palladiosimulator.spd.triggers.SimpleFireOnValue;
+import org.palladiosimulator.spd.triggers.expectations.ExpectedCount;
+import org.palladiosimulator.spd.triggers.stimuli.TaskCount;
+
+public class TaskCountTriggerChecker extends AbstractManagedElementTriggerChecker<TaskCount, ActiveResourceMeasuringPoint> {
+
+	public TaskCountTriggerChecker(SimpleFireOnValue trigger, TaskCount stimulus, TargetGroup targetGroup) {
+		super(trigger, 
+				stimulus, 
+				ActiveResourceMeasuringPoint.class, 
+				targetGroup, 
+				Set.of(ExpectedCount.class), 
+				MetricDescriptionConstants.STATE_OF_ACTIVE_RESOURCE_METRIC_TUPLE,
+				MetricDescriptionConstants.STATE_OF_ACTIVE_RESOURCE_METRIC);
+	}
+
+	@Override
+	protected boolean isMeasuringPointInTargetGroup(ActiveResourceMeasuringPoint activeResourceMP) {
+		final ProcessingResourceSpecification spec = activeResourceMP.getActiveResource();
+		return TargetGroupUtils.isContainerInTargetGroup(spec.getResourceContainer_ProcessingResourceSpecification(), targetGroup);
+	}
+	
+	@Override
+	protected double getValueForAggregation(final SlingshotMeasuringValue smv) {
+		final Measure<Long, Dimensionless> measure = smv.getMeasureForMetric(this.baseMetricDescription);
+		final long value = measure.getValue();
+		return value;
+	}
+}

--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/trigger/TaskCountTriggerChecker.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/trigger/TaskCountTriggerChecker.java
@@ -33,6 +33,7 @@ public class TaskCountTriggerChecker extends AbstractManagedElementTriggerChecke
 		return TargetGroupUtils.isContainerInTargetGroup(spec.getResourceContainer_ProcessingResourceSpecification(), targetGroup);
 	}
 	
+	/* We need to retrieve the correct type (Long) instead of Double */
 	@Override
 	protected double getValueForAggregation(final SlingshotMeasuringValue smv) {
 		final Measure<Long, Dimensionless> measure = smv.getMeasureForMetric(this.baseMetricDescription);

--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/trigger/TaskCountTriggerChecker.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/trigger/TaskCountTriggerChecker.java
@@ -5,32 +5,22 @@ import java.util.Set;
 import javax.measure.Measure;
 import javax.measure.quantity.Dimensionless;
 
-import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.utils.TargetGroupUtils;
 import org.palladiosimulator.analyzer.slingshot.monitor.data.entities.SlingshotMeasuringValue;
 import org.palladiosimulator.metricspec.constants.MetricDescriptionConstants;
-import org.palladiosimulator.pcm.resourceenvironment.ProcessingResourceSpecification;
-import org.palladiosimulator.pcmmeasuringpoint.ActiveResourceMeasuringPoint;
 import org.palladiosimulator.spd.targets.TargetGroup;
 import org.palladiosimulator.spd.triggers.SimpleFireOnValue;
 import org.palladiosimulator.spd.triggers.expectations.ExpectedCount;
 import org.palladiosimulator.spd.triggers.stimuli.TaskCount;
 
-public class TaskCountTriggerChecker extends AbstractManagedElementTriggerChecker<TaskCount, ActiveResourceMeasuringPoint> {
+public class TaskCountTriggerChecker extends AbstractManagedElementTriggerChecker<TaskCount> {
 
-	public TaskCountTriggerChecker(SimpleFireOnValue trigger, TaskCount stimulus, TargetGroup targetGroup) {
+	public TaskCountTriggerChecker(final SimpleFireOnValue trigger, final TaskCount stimulus, final TargetGroup targetGroup) {
 		super(trigger, 
-				stimulus, 
-				ActiveResourceMeasuringPoint.class, 
+				stimulus,
 				targetGroup, 
 				Set.of(ExpectedCount.class), 
 				MetricDescriptionConstants.STATE_OF_ACTIVE_RESOURCE_METRIC_TUPLE,
 				MetricDescriptionConstants.STATE_OF_ACTIVE_RESOURCE_METRIC);
-	}
-
-	@Override
-	protected boolean isMeasuringPointInTargetGroup(ActiveResourceMeasuringPoint activeResourceMP) {
-		final ProcessingResourceSpecification spec = activeResourceMP.getActiveResource();
-		return TargetGroupUtils.isContainerInTargetGroup(spec.getResourceContainer_ProcessingResourceSpecification(), targetGroup);
 	}
 	
 	/* We need to retrieve the correct type (Long) instead of Double */

--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/utils/MeasuringPointInsideTargetGroup.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/utils/MeasuringPointInsideTargetGroup.java
@@ -1,0 +1,52 @@
+package org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.utils;
+
+import org.eclipse.emf.ecore.EObject;
+import org.palladiosimulator.pcmmeasuringpoint.ActiveResourceMeasuringPoint;
+import org.palladiosimulator.pcmmeasuringpoint.ResourceContainerMeasuringPoint;
+import org.palladiosimulator.pcmmeasuringpoint.ResourceEnvironmentMeasuringPoint;
+import org.palladiosimulator.pcmmeasuringpoint.util.PcmmeasuringpointSwitch;
+import org.palladiosimulator.spd.targets.TargetGroup;
+
+/**
+ * A switch based approach of checking whether the measuring point is inside the
+ * given target group. It should return true if this is the case.
+ * 
+ * Per default, we currently return {@code false}.
+ * 
+ * TODO: Check for the remaining measuring points
+ * 
+ * @author Julijan Katic
+ */
+public class MeasuringPointInsideTargetGroup extends PcmmeasuringpointSwitch<Boolean> {
+
+	private final TargetGroup targetGroup;
+
+	public MeasuringPointInsideTargetGroup(final TargetGroup targetGroup) {
+		this.targetGroup = targetGroup;
+	}
+
+	@Override
+	public Boolean caseActiveResourceMeasuringPoint(final ActiveResourceMeasuringPoint object) {
+		return TargetGroupUtils.isContainerInTargetGroup(
+				object.getActiveResource().getResourceContainer_ProcessingResourceSpecification(), targetGroup);
+	}
+
+	@Override
+	public Boolean caseResourceContainerMeasuringPoint(final ResourceContainerMeasuringPoint object) {
+		return TargetGroupUtils.isContainerInTargetGroup(object.getResourceContainer(), targetGroup);
+	}
+
+	@Override
+	public Boolean caseResourceEnvironmentMeasuringPoint(final ResourceEnvironmentMeasuringPoint object) {
+		return object.getResourceEnvironment().getResourceContainer_ResourceEnvironment().stream()
+				.anyMatch(rc -> TargetGroupUtils.isContainerInTargetGroup(rc, targetGroup));
+	}
+
+
+	@Override
+	public Boolean defaultCase(final EObject object) {
+		return false;
+	}
+
+
+}


### PR DESCRIPTION
This PR implements the TaskCount trigger for active resources by using the STATE_OF_ACTIVE_RESOURCE measuring point.

Here, some functionality that originally belonged to `CPUUtilizationTriggerChecker` where abstracted into a `AbstractManagedElementTriggerChecker` class, since the new `TaskCountTriggerChecker` shares many of them with the CPU trigger checker, and probably other `ManagedElementTrigger`s are going to behave the same way.

When approved, this PR will close #15 .