### PR TITLE
Fix for cooldown constraint interpretation

### DIFF
--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entities/SPDAdjustorState.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entities/SPDAdjustorState.java
@@ -1,17 +1,24 @@
 package org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entities;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * This class holds the state for each scaling policy definition.
  * The state include information about when the latest adjustment
  * has happened, as well as how many scaling has happened.
  * 
- * @author Julijan Katic
+ * @author Julijan Katic, Floriment Klinaku
  */
 public final class SPDAdjustorState {
 
 	private double latestAdjustmentAtSimulationTime = 0;
 	private int numberScales = 0;
-
+	
+	// state for evaluating cooldown constraints
+	private double coolDownEnd = 0;
+	private int numberOfScalesInCooldown = 0;
+	
 	public double getLatestAdjustmentAtSimulationTime() {
 		return latestAdjustmentAtSimulationTime;
 	}
@@ -26,6 +33,26 @@ public final class SPDAdjustorState {
 	
 	public int numberOfScales() {
 		return this.numberScales;
+	}
+
+	public double getCoolDownEnd() {
+		return coolDownEnd;
+	}
+
+	public void setCoolDownEnd(double coolDownEnd) {
+		this.coolDownEnd = coolDownEnd;
+	}
+
+	public int getNumberOfScalesInCooldown() {
+		return numberOfScalesInCooldown;
+	}
+
+	public void setNumberOfScalesInCooldown(int numberOfScalesInCooldown) {
+		this.numberOfScalesInCooldown = numberOfScalesInCooldown;
+	}
+	
+	public void incrementNumberOfAdjustmentsInCooldown() {
+		this.numberOfScalesInCooldown++;
 	}
 	
 }

--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/constraint/CooldownConstraintFilter.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/constraint/CooldownConstraintFilter.java
@@ -4,6 +4,20 @@ import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entitie
 import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entities.FilterResult;
 import org.palladiosimulator.spd.constraints.policy.CooldownConstraint;
 
+
+/**
+ * The CooldownConstraint filter evaluates whether the time in which an adjustment 
+ * could potentially occur is exceeding the specified cooldown. 
+ * 
+ * In case the time is within the cooldown then the filter yields success when 
+ * the max number of adjustments within the cooldown has not yet been reached.
+ * 
+ * The state upon which the evaluation occurs is in {@link SPDAdjusterState}. 
+ * The state is altered upon a successful adjustment in the {@link Adjustor} filter. 
+ * 
+ * @author Julijan Katic, Floriment Klinaku
+ *
+ */
 public class CooldownConstraintFilter extends AbstractConstraintFilter<CooldownConstraint> {
 
 	public CooldownConstraintFilter(final CooldownConstraint constraint) {
@@ -12,17 +26,17 @@ public class CooldownConstraintFilter extends AbstractConstraintFilter<CooldownC
 
 	@Override
 	public FilterResult doProcess(final FilterObjectWrapper event) {
-		final int numberScales = event.getState().numberOfScales();
-		final double lastScaling = event.getState().getLatestAdjustmentAtSimulationTime();
+		final int numberScalesInCooldown = event.getState().getNumberOfScalesInCooldown();
+		final double cooldownEnd = event.getState().getCoolDownEnd();
 		
-		if (event.getEventToFilter().time() >= lastScaling + constraint.getCooldownTime()) {
-			if (numberScales < constraint.getMaxScalingOperations()) {
+		if(event.getEventToFilter().time()>=cooldownEnd) {
+			return FilterResult.success(event.getEventToFilter());
+		} else {
+			if (numberScalesInCooldown < constraint.getMaxScalingOperations()) {
 				return FilterResult.success(event.getEventToFilter());
 			} else {
-				return FilterResult.disregard(String.format("Max number scales reached: %d >= %d", numberScales, constraint.getMaxScalingOperations()));
+				return FilterResult.disregard(String.format("Max number scales reached: %d >= %d", numberScalesInCooldown, constraint.getMaxScalingOperations()));
 			}
-		} else {
-			return FilterResult.disregard(String.format("Cooldown not reached yet: %d < %d", event.getEventToFilter().time() - lastScaling, constraint.getCooldownTime()));
 		}
 	}
 


### PR DESCRIPTION
This PR is a fix for the interpretation of cooldowns in SPD. 

Before: 

When having a cooldown with time 1.0 and max operation set to 1 during the cooldown, the interpretation allowed in total a maximum of one operation, see figure below: 

<img width="1224" alt="Screenshot 2023-09-30 at 21 46 22" src="https://github.com/PalladioSimulator/Palladio-Analyzer-Slingshot-Extension-SPD-Interpreter/assets/1203153/3227c239-a464-40a6-82ed-0fb0ef497783">

After:

After this PR, the cooldown is interpreted correctly as documented in https://palladiosimulator.github.io/Palladio-Documentation-Slingshot/constraints/: 

<img width="1222" alt="Screenshot 2023-09-30 at 21 46 12" src="https://github.com/PalladioSimulator/Palladio-Analyzer-Slingshot-Extension-SPD-Interpreter/assets/1203153/60ed1141-0229-435d-859b-a8a7e511e6f0">



