### PR TITLE
Add SimpeFireOnTrend

### DIFF
--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/aggregator/ChangeWindowAggregation.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/aggregator/ChangeWindowAggregation.java
@@ -1,0 +1,28 @@
+package org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entity.aggregator;
+
+import java.util.Deque;
+
+/**
+ * This aggregator finds the average change of discrete values over the time.
+ * The average change is defined to be {@code (f(x_0) - f(x_t)) / (x_0 - x_t)}.
+ * 
+ * Here, the latest value and the oldest value of the fixed window will be used.
+ * 
+ * @author Julijan Katic
+ *
+ */
+public class ChangeWindowAggregation extends FixedLengthWindowAggregation {
+
+	public ChangeWindowAggregation(int windowSize) {
+		super(windowSize);
+	}
+
+	@Override
+	protected double doAggregation() {
+		final double firstValue = ((Deque<Double>) valuesToConsider).getFirst();
+		final double secondValue = ((Deque<Double>) valuesToConsider).getLast();
+
+		return (secondValue - firstValue) / valuesToConsider.size();
+	}
+
+}

--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/trigger/CPUUtilizationTriggerChecker.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/trigger/CPUUtilizationTriggerChecker.java
@@ -4,13 +4,13 @@ import java.util.Set;
 
 import org.palladiosimulator.metricspec.constants.MetricDescriptionConstants;
 import org.palladiosimulator.spd.targets.TargetGroup;
-import org.palladiosimulator.spd.triggers.SimpleFireOnValue;
+import org.palladiosimulator.spd.triggers.BaseTrigger;
 import org.palladiosimulator.spd.triggers.expectations.ExpectedPercentage;
 import org.palladiosimulator.spd.triggers.stimuli.CPUUtilization;
 
 public class CPUUtilizationTriggerChecker extends AbstractManagedElementTriggerChecker<CPUUtilization> {
 
-	public CPUUtilizationTriggerChecker(final SimpleFireOnValue trigger,
+	public CPUUtilizationTriggerChecker(final BaseTrigger trigger,
 										final CPUUtilization stimulus,
 								 		final TargetGroup targetGroup) {
 		super(trigger, 

--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/trigger/OperationResponseTimeTriggerChecker.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/trigger/OperationResponseTimeTriggerChecker.java
@@ -15,13 +15,13 @@ import org.palladiosimulator.edp2.models.measuringpoint.MeasuringPoint;
 import org.palladiosimulator.metricspec.constants.MetricDescriptionConstants;
 import org.palladiosimulator.pcm.repository.OperationSignature;
 import org.palladiosimulator.pcmmeasuringpoint.OperationReference;
-import org.palladiosimulator.spd.triggers.SimpleFireOnValue;
+import org.palladiosimulator.spd.triggers.BaseTrigger;
 import org.palladiosimulator.spd.triggers.expectations.ExpectedTime;
 import org.palladiosimulator.spd.triggers.stimuli.OperationResponseTime;
 
 public final class OperationResponseTimeTriggerChecker extends TriggerChecker<OperationResponseTime> {
 
-	public OperationResponseTimeTriggerChecker(final SimpleFireOnValue trigger) {
+	public OperationResponseTimeTriggerChecker(final BaseTrigger trigger) {
 		super(trigger, OperationResponseTime.class, Set.of(ExpectedTime.class));
 	}
 

--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/trigger/SimpleFireOnTrendComparator.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/trigger/SimpleFireOnTrendComparator.java
@@ -1,6 +1,8 @@
 package org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entity.trigger;
 
 import org.palladiosimulator.spd.triggers.SimpleFireOnTrend;
+import org.palladiosimulator.spd.triggers.TrendPattern;
+import org.palladiosimulator.spd.triggers.expectations.ExpectedTrend;
 import org.palladiosimulator.spd.triggers.expectations.ExpectedValue;
 
 /*
@@ -17,7 +19,22 @@ public class SimpleFireOnTrendComparator implements ValueComparator {
 	
 	@Override
 	public ComparatorResult compare(double actualValue, ExpectedValue expectedValue) {
-		throw new UnsupportedOperationException("This is not yet implemented and only exist as a placeholder right now");
+		// Pre-condition: The "actualValue" is already aggregated and a change
+		if (!(expectedValue instanceof ExpectedTrend)) {
+			throw new IllegalArgumentException("For the SimpleFireOnTrend, the ExpectedTrend must be used");
+		}
+
+		final ExpectedTrend expectedTrend = (ExpectedTrend) expectedValue;
+
+		final boolean result = switch (expectedTrend.getTrend().getValue()) {
+		case TrendPattern.INCREASING_VALUE -> actualValue > 0;
+		case TrendPattern.DECREASING_VALUE -> actualValue < 0;
+		case TrendPattern.NON_INCREASING_VALUE -> actualValue <= 0;
+		case TrendPattern.NON_DECREASING_VALUE -> actualValue >= 0;
+		default -> false;
+		};
+
+		return result ? ComparatorResult.IN_ACCORDANCE : ComparatorResult.DISREGARD;
 	}
 
 }

--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/trigger/SimulationTimeChecker.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/trigger/SimulationTimeChecker.java
@@ -6,13 +6,14 @@ import org.palladiosimulator.analyzer.slingshot.behavior.spd.data.SimulationTime
 import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entities.FilterObjectWrapper;
 import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entities.FilterResult;
 import org.palladiosimulator.analyzer.slingshot.common.events.DESEvent;
+import org.palladiosimulator.spd.triggers.BaseTrigger;
 import org.palladiosimulator.spd.triggers.SimpleFireOnValue;
 import org.palladiosimulator.spd.triggers.expectations.ExpectedTime;
 import org.palladiosimulator.spd.triggers.stimuli.SimulationTime;
 
 public final class SimulationTimeChecker extends TriggerChecker<SimulationTime> {
 
-	public SimulationTimeChecker(final SimpleFireOnValue trigger) {
+	public SimulationTimeChecker(final BaseTrigger trigger) {
 		super(trigger, SimulationTime.class, Set.of(ExpectedTime.class));
 	}
 

--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/trigger/TaskCountTriggerChecker.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/trigger/TaskCountTriggerChecker.java
@@ -8,13 +8,13 @@ import javax.measure.quantity.Dimensionless;
 import org.palladiosimulator.analyzer.slingshot.monitor.data.entities.SlingshotMeasuringValue;
 import org.palladiosimulator.metricspec.constants.MetricDescriptionConstants;
 import org.palladiosimulator.spd.targets.TargetGroup;
-import org.palladiosimulator.spd.triggers.SimpleFireOnValue;
+import org.palladiosimulator.spd.triggers.BaseTrigger;
 import org.palladiosimulator.spd.triggers.expectations.ExpectedCount;
 import org.palladiosimulator.spd.triggers.stimuli.TaskCount;
 
 public class TaskCountTriggerChecker extends AbstractManagedElementTriggerChecker<TaskCount> {
 
-	public TaskCountTriggerChecker(final SimpleFireOnValue trigger, final TaskCount stimulus, final TargetGroup targetGroup) {
+	public TaskCountTriggerChecker(final BaseTrigger trigger, final TaskCount stimulus, final TargetGroup targetGroup) {
 		super(trigger, 
 				stimulus,
 				targetGroup, 


### PR DESCRIPTION
This PR adds the ability to also have SimpleFireOnTrend triggers. It includes a new aggregator called `ChangeWindowAggregation` that calculates the average change (trend) of the latest `window_size` values.

Furthermore, before, most triggers assumed `SimpleFireOnValue` in their constructors. Now, these have been changed to simply `BaseTrigger` to also enable `SimpleFireOnTrend`. 