### PR TITLE
Create monitors when cloning resource containers

### DIFF
--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd.adjustment/META-INF/MANIFEST.MF
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd.adjustment/META-INF/MANIFEST.MF
@@ -23,3 +23,4 @@ Require-Bundle: org.palladiosimulator.analyzer.slingshot.behavior.spd.data;bundl
  org.palladiosimulator.spd.semantic;bundle-version="1.0.0",
  org.palladiosimulator.analyzer.slingshot.ui.events;bundle-version="1.0.0",
  org.palladiosimulator.analyzer.slingshot.workflow.events;bundle-version="1.0.0"
+Export-Package: org.palladiosimulator.analyzer.slingshot.behavior.spd.monitor

--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd.adjustment/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/monitor/ResourceContainerMonitorCloner.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd.adjustment/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/monitor/ResourceContainerMonitorCloner.java
@@ -1,0 +1,167 @@
+package org.palladiosimulator.analyzer.slingshot.behavior.spd.monitor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.palladiosimulator.edp2.models.measuringpoint.MeasuringPoint;
+import org.palladiosimulator.edp2.models.measuringpoint.MeasuringPointRepository;
+import org.palladiosimulator.monitorrepository.Monitor;
+import org.palladiosimulator.monitorrepository.MonitorRepository;
+import org.palladiosimulator.monitorrepository.MonitorRepositoryFactory;
+import org.palladiosimulator.pcm.resourceenvironment.ProcessingResourceSpecification;
+import org.palladiosimulator.pcm.resourceenvironment.ResourceContainer;
+import org.palladiosimulator.pcmmeasuringpoint.ActiveResourceMeasuringPoint;
+import org.palladiosimulator.pcmmeasuringpoint.PcmmeasuringpointFactory;
+import org.palladiosimulator.pcmmeasuringpoint.ResourceContainerMeasuringPoint;
+
+/**
+ * A class that clones monitors (and measuring points) of a resource container
+ * and its active resource specifications.
+ * 
+ * Everytime a cloning action is performed, the monitor is also saved directly
+ * into the repository.
+ * 
+ * @author Julijan Katic
+ */
+public class ResourceContainerMonitorCloner {
+
+	private final MeasuringPointRepository mpRepository;
+	private final MonitorRepository monitorRepository;
+
+	/** The list of monitors that are connected to the unit resource container */
+	private final List<Monitor> unitResourceContainerMonitors;
+
+	/**
+	 * The list of monitors that are connected to the resource specs of the unit
+	 * container.
+	 */
+	private final List<Monitor> unitActiveResourceMonitors;
+
+	/**
+	 * Constructs this class.
+	 * 
+	 * @param monitorRepository The monitor repository, needed to save the cloned
+	 *                          monitors there.
+	 * @param mpRepository      The measuring point repository, needed to save the
+	 *                          cloned MPs there.
+	 * @param unit              The resource container unit which is used to clone
+	 *                          containers.
+	 */
+	public ResourceContainerMonitorCloner(final MonitorRepository monitorRepository,
+			final MeasuringPointRepository mpRepository, final ResourceContainer unit) {
+		this.mpRepository = mpRepository;
+		this.monitorRepository = monitorRepository;
+
+		final ResourceContainerMonitorFinder finder = new ResourceContainerMonitorFinder(monitorRepository);
+		this.unitResourceContainerMonitors = finder.doSwitch(unit);
+		this.unitActiveResourceMonitors = unit.getActiveResourceSpecifications_ResourceContainer().stream()
+				.flatMap(ar -> finder.doSwitch(ar).stream()).toList();
+
+	}
+
+	/**
+	 * Creates ("clones") new monitors for the resource container itself and its
+	 * active resource specifications. For each monitor that reference the unit
+	 * resource container, there will be a new monitor of the same type for the
+	 * copied resource container. The same is true for the active resource specs.
+	 * However, because it is not possible to track from where the copied spec is
+	 * copied from, only the resource type will be considered.
+	 * 
+	 * For example, if there were monitors for each spec SPEC1 of type CPU and SPEC2
+	 * of type HDD in the unit container, there are going to be new monitors for the
+	 * copied specs. However, if the unit container contains two specs of the same
+	 * type, only one of the copied specs gets a new monitor.
+	 * 
+	 * @param copiedResourceContainer
+	 * @return
+	 */
+	public List<Monitor> createMonitorsForResourceContainer(final ResourceContainer copiedResourceContainer) {
+		final List<Monitor> monitors = new ArrayList<>(
+				unitResourceContainerMonitors.size() + unitActiveResourceMonitors.size());
+
+		this.unitResourceContainerMonitors.stream()
+				.map(unitMonitor -> createMonitor(copiedResourceContainer, unitMonitor)).forEach(monitors::add);
+
+		this.unitActiveResourceMonitors.stream()
+			.<Monitor>mapMulti((monitor, acceptor) -> {
+				final ActiveResourceMeasuringPoint ap = (ActiveResourceMeasuringPoint) monitor.getMeasuringPoint();
+				copiedResourceContainer.getActiveResourceSpecifications_ResourceContainer().stream()
+						.filter(spec -> isSameProcessingType(spec, ap.getActiveResource()))
+						.findAny()
+						.ifPresent(spec -> acceptor.accept(createMonitor(spec, monitor)));
+			}).forEach(monitors::add);
+
+		return monitors;
+	}
+
+	private static boolean isSameProcessingType(final ProcessingResourceSpecification firstSpec,
+			final ProcessingResourceSpecification secondSpec) {
+		return firstSpec.getActiveResourceType_ActiveResourceSpecification().getId()
+				.equals(secondSpec.getActiveResourceType_ActiveResourceSpecification().getId());
+	}
+
+	private Monitor createMonitor(final ResourceContainer resourceContainer, final Monitor originalMonitor) {
+		final Monitor monitor = createMonitor(originalMonitor);
+		monitor.setMeasuringPoint(createMeasuringPoint(resourceContainer, originalMonitor.getMeasuringPoint()));
+		return monitor;
+	}
+
+	private MeasuringPoint createMeasuringPoint(final ResourceContainer resourceContainer,
+			final MeasuringPoint originalMeasuringPoint) {
+		if (originalMeasuringPoint instanceof ResourceContainerMeasuringPoint) {
+			final ResourceContainerMeasuringPoint copy = PcmmeasuringpointFactory.eINSTANCE
+					.createResourceContainerMeasuringPoint();
+			copy.setMeasuringPointRepository(mpRepository);
+			copy.setResourceContainer(resourceContainer);
+			mpRepository.getMeasuringPoints().add(copy);
+			return copy;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Helper method that creates a generic monitor without a reference to a
+	 * measuring point. Every attribute is copied from the original monitor, except:
+	 * - The reference to the old measuring point - The entity name will contain the
+	 * old name, but with "-copy" appended - The id will be newly generated
+	 * 
+	 * @param originalMonitor The original monitor to copy from
+	 * @return A new monitor
+	 */
+	private Monitor createMonitor(final Monitor originalMonitor) {
+		final Monitor monitor = MonitorRepositoryFactory.eINSTANCE.createMonitor();
+
+		monitor.setActivated(originalMonitor.isActivated());
+		monitor.setEntityName(originalMonitor.getEntityName() + "-copy");
+		monitor.setId(EcoreUtil.generateUUID());
+		monitor.getMeasurementSpecifications().addAll(originalMonitor.getMeasurementSpecifications());
+
+		monitor.setMonitorRepository(monitorRepository);
+		monitorRepository.getMonitors().add(monitor);
+
+		return monitor;
+	}
+
+	private Monitor createMonitor(final ProcessingResourceSpecification spec, final Monitor originalMonitor) {
+		final Monitor monitor = createMonitor(originalMonitor);
+		monitor.setMeasuringPoint(createMeasuringPoint(spec, originalMonitor.getMeasuringPoint()));
+		return monitor;
+	}
+
+	private MeasuringPoint createMeasuringPoint(final ProcessingResourceSpecification spec,
+			final MeasuringPoint originalMeasuringPoint) {
+		if (originalMeasuringPoint instanceof final ActiveResourceMeasuringPoint acMP) {
+			final ActiveResourceMeasuringPoint copy = PcmmeasuringpointFactory.eINSTANCE
+					.createActiveResourceMeasuringPoint();
+			copy.setMeasuringPointRepository(mpRepository);
+			copy.setActiveResource(spec);
+			copy.setReplicaID(acMP.getReplicaID());
+			mpRepository.getMeasuringPoints().add(copy);
+			return copy;
+		}
+
+		return null;
+	}
+}

--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd.adjustment/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/monitor/ResourceContainerMonitorFinder.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd.adjustment/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/monitor/ResourceContainerMonitorFinder.java
@@ -1,0 +1,54 @@
+package org.palladiosimulator.analyzer.slingshot.behavior.spd.monitor;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.emf.ecore.EObject;
+import org.palladiosimulator.monitorrepository.Monitor;
+import org.palladiosimulator.monitorrepository.MonitorRepository;
+import org.palladiosimulator.pcm.resourceenvironment.ProcessingResourceSpecification;
+import org.palladiosimulator.pcm.resourceenvironment.ResourceContainer;
+import org.palladiosimulator.pcm.resourceenvironment.util.ResourceenvironmentSwitch;
+import org.palladiosimulator.pcmmeasuringpoint.ActiveResourceMeasuringPoint;
+import org.palladiosimulator.pcmmeasuringpoint.ResourceContainerMeasuringPoint;
+
+/**
+ * This class is used to find all the monitors of a certain element within a
+ * resource environment. It returns a list of monitors that has a measuring
+ * point to the queried element.
+ * 
+ * @author Julijan Katic
+ */
+public final class ResourceContainerMonitorFinder extends ResourceenvironmentSwitch<List<Monitor>> {
+
+	private final MonitorRepository monitorRepository;
+
+	public ResourceContainerMonitorFinder(final MonitorRepository monitorRepository) {
+		this.monitorRepository = monitorRepository;
+	}
+
+	@Override
+	public List<Monitor> caseResourceContainer(ResourceContainer object) {
+		return monitorRepository.getMonitors().stream()
+				.filter(monitor -> monitor.getMeasuringPoint() instanceof ResourceContainerMeasuringPoint)
+				.filter(monitor -> ((ResourceContainerMeasuringPoint) monitor.getMeasuringPoint())
+						.getResourceContainer().getId().equals(object.getId()))
+				.toList();
+	}
+
+	@Override
+	public List<Monitor> caseProcessingResourceSpecification(ProcessingResourceSpecification object) {
+		return monitorRepository.getMonitors().stream()
+				.filter(monitor -> monitor.getMeasuringPoint() instanceof ActiveResourceMeasuringPoint)
+				.filter(monitor -> ((ActiveResourceMeasuringPoint) monitor.getMeasuringPoint()).getActiveResource()
+						.getId().equals(object.getId()))
+				.toList();
+	}
+
+	@Override
+	public List<Monitor> defaultCase(EObject object) {
+		return Collections.emptyList();
+	}
+
+
+}

--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd.data/META-INF/MANIFEST.MF
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd.data/META-INF/MANIFEST.MF
@@ -7,6 +7,7 @@ Automatic-Module-Name: org.palladiosimulator.analyzer.slingshot.behavior.spd.dat
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.palladiosimulator.analyzer.slingshot.common;bundle-version="1.0.0",
  org.palladiosimulator.pcm,
- org.palladiosimulator.spd
+ org.palladiosimulator.spd,
+ org.palladiosimulator.monitorrepository
 Export-Package: org.palladiosimulator.analyzer.slingshot.behavior.spd.data,
  org.palladiosimulator.analyzer.slingshot.behavior.spd.data.adjustment

--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd.data/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/data/adjustment/MonitorChange.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd.data/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/data/adjustment/MonitorChange.java
@@ -1,0 +1,29 @@
+package org.palladiosimulator.analyzer.slingshot.behavior.spd.data.adjustment;
+
+import org.palladiosimulator.monitorrepository.Monitor;
+
+public final class MonitorChange extends ModelChange<Monitor> {
+
+	private final Monitor copiedFrom;
+	private final Monitor newMonitor;
+
+	public MonitorChange(Monitor object, Monitor copiedFrom, double simulationTime) {
+		super(object, Monitor.class, simulationTime);
+		this.newMonitor = object;
+		this.copiedFrom = copiedFrom;
+	}
+
+	public Monitor getCopiedFrom() {
+		return copiedFrom;
+	}
+
+	/**
+	 * Synonym for {@link #getObject()}.
+	 * 
+	 * @see #getObject()
+	 */
+	public Monitor getNewMonitor() {
+		return newMonitor;
+	}
+
+}


### PR DESCRIPTION
Before, there were no new monitors created for each resource container. Now, if the unit container also had monitors, then the cloned resource container will also have monitors.

TODO: There are still some exceptions occuring regarding resolving URIs for measuring points