### PR TITLE
NetworkUtilization

### DIFF
--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/StimuliInterpreter.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/StimuliInterpreter.java
@@ -3,6 +3,7 @@ package org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter;
 import org.palladiosimulator.analyzer.slingshot.behavior.spd.data.SimulationTimeReached;
 import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.ScalingTriggerInterpreter.InterpretationResult;
 import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entity.trigger.CPUUtilizationTriggerChecker;
+import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entity.trigger.NetworkUtilizationTriggerChecker;
 import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entity.trigger.OperationResponseTimeTriggerChecker;
 import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entity.trigger.QueueLengthTriggerChecker;
 import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entity.trigger.SimulationTimeChecker;
@@ -16,6 +17,7 @@ import org.palladiosimulator.spd.triggers.expectations.ExpectedPercentage;
 import org.palladiosimulator.spd.triggers.expectations.ExpectedTime;
 import org.palladiosimulator.spd.triggers.expectations.ExpectedValue;
 import org.palladiosimulator.spd.triggers.stimuli.CPUUtilization;
+import org.palladiosimulator.spd.triggers.stimuli.NetworkUtilization;
 import org.palladiosimulator.spd.triggers.stimuli.OperationResponseTime;
 import org.palladiosimulator.spd.triggers.stimuli.QueueLength;
 import org.palladiosimulator.spd.triggers.stimuli.SimulationTime;
@@ -74,6 +76,8 @@ final class StimuliInterpreter extends StimuliSwitch<InterpretationResult> {
 																   this.scalingTriggerInterpreter.policy.getTargetGroup())
 												   		  );
 	}
+	
+	
 
 	@Override
 	public InterpretationResult caseTaskCount(final TaskCount object) {
@@ -94,6 +98,22 @@ final class StimuliInterpreter extends StimuliSwitch<InterpretationResult> {
 		return (new InterpretationResult()).listenEvent(Subscriber.builder(MeasurementMade.class).name("queueLength"))
 				.triggerChecker(new QueueLengthTriggerChecker(this.trigger, object));
 	}
+	
+	@Override
+	public InterpretationResult caseNetworkUtilization(NetworkUtilization object) {
+		final ExpectedPercentage expectedPercentage = this.checkExpectedValue(ExpectedPercentage.class);
+		Preconditions.checkArgument(0 <= expectedPercentage.getValue() && expectedPercentage.getValue() <= 100, 
+									"The expected percentage must be between 0 and 100");
+		
+		
+		return (new InterpretationResult()).listenEvent(Subscriber.builder(MeasurementMade.class)
+																  .name("networkUtilizationMade"))
+										   .triggerChecker(new NetworkUtilizationTriggerChecker(
+												   				   this.trigger, 
+																   object, 
+																   this.scalingTriggerInterpreter.policy.getTargetGroup())
+												   		  );
+	}
 
 	@SuppressWarnings("unchecked")
 	private <T extends ExpectedValue> T checkExpectedValue(final Class<T> expectedType) {
@@ -106,4 +126,8 @@ final class StimuliInterpreter extends StimuliSwitch<InterpretationResult> {
 		
 		return (T) this.trigger.getExpectedValue();
 	}
+
+
+
+	
 }

--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/trigger/NetworkUtilizationTriggerChecker.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/trigger/NetworkUtilizationTriggerChecker.java
@@ -1,0 +1,21 @@
+package org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entity.trigger;
+
+import java.util.Set;
+
+import org.palladiosimulator.metricspec.constants.MetricDescriptionConstants;
+import org.palladiosimulator.spd.targets.TargetGroup;
+import org.palladiosimulator.spd.triggers.BaseTrigger;
+import org.palladiosimulator.spd.triggers.expectations.ExpectedPercentage;
+import org.palladiosimulator.spd.triggers.stimuli.NetworkUtilization;
+
+public class NetworkUtilizationTriggerChecker extends AbstractManagedElementTriggerChecker<NetworkUtilization> {
+
+	public NetworkUtilizationTriggerChecker(BaseTrigger trigger, NetworkUtilization stimulus, TargetGroup targetGroup) {
+		super(trigger, stimulus, targetGroup, Set.of(ExpectedPercentage.class),
+				MetricDescriptionConstants.UTILIZATION_OF_ACTIVE_RESOURCE_TUPLE,
+				MetricDescriptionConstants.UTILIZATION_OF_ACTIVE_RESOURCE);
+		// TODO Auto-generated constructor stub
+	}
+
+
+}

--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/utils/MeasuringPointInsideTargetGroup.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/utils/MeasuringPointInsideTargetGroup.java
@@ -3,6 +3,7 @@ package org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.utils;
 import org.eclipse.emf.ecore.EObject;
 import org.palladiosimulator.pcmmeasuringpoint.ActiveResourceMeasuringPoint;
 import org.palladiosimulator.pcmmeasuringpoint.AssemblyReference;
+import org.palladiosimulator.pcmmeasuringpoint.LinkingResourceMeasuringPoint;
 import org.palladiosimulator.pcmmeasuringpoint.OperationReference;
 import org.palladiosimulator.pcmmeasuringpoint.ResourceContainerMeasuringPoint;
 import org.palladiosimulator.pcmmeasuringpoint.ResourceEnvironmentMeasuringPoint;
@@ -59,5 +60,9 @@ public class MeasuringPointInsideTargetGroup extends PcmmeasuringpointSwitch<Boo
 		return false;
 	}
 
+	@Override
+	public Boolean caseLinkingResourceMeasuringPoint(LinkingResourceMeasuringPoint object) {
+		return TargetGroupUtils.isLinkingResourceInTargetGroup(object.getLinkingResource(), targetGroup);
+	}
 
 }

--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/utils/TargetGroupUtils.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/utils/TargetGroupUtils.java
@@ -9,6 +9,7 @@ import org.palladiosimulator.pcm.allocation.AllocationContext;
 import org.palladiosimulator.pcm.core.composition.AssemblyContext;
 import org.palladiosimulator.pcm.repository.OperationProvidedRole;
 import org.palladiosimulator.pcm.repository.OperationSignature;
+import org.palladiosimulator.pcm.resourceenvironment.LinkingResource;
 import org.palladiosimulator.pcm.resourceenvironment.ResourceContainer;
 import org.palladiosimulator.semanticspd.CompetingConsumersGroupCfg;
 import org.palladiosimulator.semanticspd.Configuration;
@@ -43,6 +44,21 @@ public class TargetGroupUtils {
 						  .getResourceContainer_ResourceEnvironment()
 						  .stream()
 						  .anyMatch(rc -> rc.getId().equals(container.getId()));
+	}
+	
+	public static boolean isLinkingResourceInInfrastructure(final LinkingResource linkingResource, final ElasticInfrastructure targetGroup) {
+		return targetGroup.getPCM_ResourceEnvironment()
+						  .getLinkingResources__ResourceEnvironment()
+						  .stream()
+						  .anyMatch(lr -> linkingResource.getId().equals(lr.getId()));
+	}
+	
+	public static boolean isLinkingResourceInTargetGroup(final LinkingResource linkingResource, final TargetGroup targetGroup) {
+		if (targetGroup instanceof final ElasticInfrastructure ei) {
+			return isLinkingResourceInInfrastructure(linkingResource, ei);
+		}
+		
+		return false;
 	}
 	
 	/**


### PR DESCRIPTION
This PR adds the `NetworkUtilization` trigger.

This trigger is very similar to the `CPUUtilization`. However, the filter before this trigger will ensure that only measurements that were made on the `LinkingResource` measuring point will get through.