### PR TITLE
Single partition for Qvto cache 

### DIFF
--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd.adjustment/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/adjustment/qvto/util/QVToModelCache.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd.adjustment/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/adjustment/qvto/util/QVToModelCache.java
@@ -211,12 +211,6 @@ public class QVToModelCache {
     
     private void storeBlackboardModels() {
     	assert this.blackboard != null;
-    	
-    	final Set<String> partitions = new HashSet<>(blackboard.getPartitionIds());
-    	partitions.remove(ConstantsContainer.DEFAULT_PCM_INSTANCE_PARTITION_ID);
-    	partitions.forEach(this::storeModelFromBlackboardPartition);
-    	
-    	// We store the default partition last, to avoid conflicts with similar models.
     	storeModelFromBlackboardPartition(ConstantsContainer.DEFAULT_PCM_INSTANCE_PARTITION_ID);
     }
     


### PR DESCRIPTION
In this PR we restrict the cache to store models from the only one single partition, which is the default partition that Slingshot uses.

The goal is to avoid some undesired behavior when running Slingshot through the Experiment Automation. 

