### PR TITLE
Switch order of filters in filterchain.

### DIFF
--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entities/SPDAdjustorContext.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entities/SPDAdjustorContext.java
@@ -8,35 +8,37 @@ import org.apache.log4j.Logger;
 import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entity.adjustor.Adjustor;
 import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entity.constraint.AbstractConstraintFilter;
 import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entity.targetgroup.TargetGroupChecker;
+import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entity.trigger.TriggerChecker;
 import org.palladiosimulator.analyzer.slingshot.common.events.DESEvent;
 import org.palladiosimulator.analyzer.slingshot.eventdriver.entity.EventHandler;
 import org.palladiosimulator.analyzer.slingshot.eventdriver.entity.Subscriber;
 import org.palladiosimulator.analyzer.slingshot.eventdriver.returntypes.Result;
 import org.palladiosimulator.spd.ScalingPolicy;
+import org.palladiosimulator.spd.triggers.ScalingTrigger;
 
 public final class SPDAdjustorContext {
 
 	private static final Logger LOGGER = Logger.getLogger(SPDAdjustorContext.class);
-	
+
 	private final FilterChain filterChain;
-	private final ScalingPolicy scalingPolicy;	
+	private final ScalingPolicy scalingPolicy;
 	private final List<Subscriber<? extends DESEvent>> associatedHandlers;
 
 	private SPDAdjustorState state = new SPDAdjustorState();
-	private SPDAdjustorState previousState = new SPDAdjustorState();
-	
-	public SPDAdjustorContext(final ScalingPolicy policy, 
+	private final SPDAdjustorState previousState = new SPDAdjustorState();
+
+	public SPDAdjustorContext(final ScalingPolicy policy,
 			final Filter triggerChecker,
 			final List<Subscriber.Builder<? extends DESEvent>> associatedHandlers) {
 		this.scalingPolicy = policy;
-		
+
 		this.filterChain = new FilterChain(this::doOnDisregard, state);
-		
+
 		initializeFilterChain(triggerChecker);
-		
+
 		final PublishResultingEventFilter publisher = new PublishResultingEventFilter();
 
-		
+
 		this.associatedHandlers = associatedHandlers.stream()
 				.map(builder -> builder.handler(publisher))
 				.map(builder -> builder.build())
@@ -44,17 +46,27 @@ public final class SPDAdjustorContext {
 	}
 
 
+	/**
+	 * Initializes the filter chain.
+	 *
+	 * The first filter is always a {@link TargetGroupChecker}, the second filter is
+	 * always a {@link TriggerChecker}, the last filter is always the
+	 * {@link Adjustor}. In between are the Checker for the Constraints.
+	 *
+	 * @param triggerChecker filter to check the policie's {@link ScalingTrigger}.
+	 */
 	private void initializeFilterChain(final Filter triggerChecker) {
 		this.filterChain.add(new TargetGroupChecker(this.scalingPolicy.getTargetGroup()));
-		
-		scalingPolicy.getPolicyConstraints().forEach(constraint -> 
+
+		this.filterChain.add(triggerChecker);
+
+		scalingPolicy.getPolicyConstraints().forEach(constraint ->
 						this.filterChain.add(AbstractConstraintFilter.createAbstractConstraintFilter(constraint))
 					);
-		
-		this.filterChain.add(triggerChecker);
+
 		this.filterChain.add(new Adjustor(this.scalingPolicy));
 	}
-	
+
 
 	public FilterChain getFilterChain() {
 		return filterChain;
@@ -67,7 +79,7 @@ public final class SPDAdjustorContext {
 	public List<Subscriber<? extends DESEvent>> getAssociatedHandlers() {
 		return associatedHandlers;
 	}
-	
+
 	private void doOnDisregard(final Object reason) {
 		this.state = previousState;
 		LOGGER.info("Filter was not successful: " + reason.toString());
@@ -88,26 +100,26 @@ public final class SPDAdjustorContext {
 		}
 		return false;
 	}
-	
+
 	/**
 	 * After all filters are successful, the resulting event should be published.
 	 */
 	private class PublishResultingEventFilter implements EventHandler<DESEvent> {
-		
+
 		@Override
-		public Result<?> acceptEvent(DESEvent event) throws Exception {
+		public Result<?> acceptEvent(final DESEvent event) throws Exception {
 			filterChain.next(event);
 			final FilterResult filterResult = filterChain.getLatestResult();
-			
+
 			if (filterResult instanceof final FilterResult.Success success) {
 				final Object result = success.nextEvent();
 				LOGGER.debug("Got a result after filtering! " + result.getClass().getSimpleName());
-				
+
 				return Result.of(result);
 			} else {
 				return Result.empty();
 			}
 		}
-		
+
 	}
 }


### PR DESCRIPTION
## Current Behavior.

Filters in the FilterChain are ordered like this:
TG Checker -> ConstraintChecker -> TriggerChecker -> Adjustor

Problem : All events are constraint-checked even if they wont make it through the trigger check at all. 

## New Behavior.

Filters in the FilterChain are ordered like this:
TG Checker ->  TriggerChecker  -> ConstraintChecker -> Adjustor

Such that only event, that pass the trigger are constrained checked.

## Note 
The best order would probably be:
TG Checker -> TG ConstraintChecker -> TriggerChecker -> Scaling Policy ConstraintChecker -> Adjustor
But that should be another Issue.

This PR will close #27.