### PR TITLE
Yet Another Attempt to fix Compound Filters. 

### DIFF
--- a/bundles/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/StimuliInterpreter.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/StimuliInterpreter.java
@@ -45,11 +45,9 @@ final class StimuliInterpreter extends StimuliSwitch<InterpretationResult> {
 
 		return (new InterpretationResult()).scheduleEvent(event)
 										   .listenEvent(Subscriber.builder(SimulationTimeReached.class)
-												   				  .name("something"))
+						.name("SimulationTimeReachedSubscriber"))
 										   .triggerChecker(new SimulationTimeChecker(this.trigger));
 	}
-
-
 
 	@Override
 	public InterpretationResult caseOperationResponseTime(final OperationResponseTime object) {
@@ -58,19 +56,19 @@ final class StimuliInterpreter extends StimuliSwitch<InterpretationResult> {
 																  .name("measurementMade"))
 									       .triggerChecker(new OperationResponseTimeTriggerChecker(this.trigger));
 	}
-	
+
 	@Override
 	public InterpretationResult caseCPUUtilization(final CPUUtilization object) {
 		final ExpectedPercentage expectedPercentage = this.checkExpectedValue(ExpectedPercentage.class);
-		Preconditions.checkArgument(0 <= expectedPercentage.getValue() && expectedPercentage.getValue() <= 100, 
+		Preconditions.checkArgument(0 <= expectedPercentage.getValue() && expectedPercentage.getValue() <= 100,
 									"The expected percentage must be between 0 and 100");
-		
-		
+
+
 		return (new InterpretationResult()).listenEvent(Subscriber.builder(MeasurementMade.class)
 																  .name("cpuUtilizationMade"))
 										   .triggerChecker(new CPUUtilizationTriggerChecker(
-												   				   this.trigger, 
-																   object, 
+												   				   this.trigger,
+																   object,
 																   this.scalingTriggerInterpreter.policy.getTargetGroup())
 												   		  );
 	}
@@ -78,7 +76,7 @@ final class StimuliInterpreter extends StimuliSwitch<InterpretationResult> {
 	@Override
 	public InterpretationResult caseTaskCount(final TaskCount object) {
 		this.checkExpectedValue(ExpectedCount.class);
-		
+
 		return (new InterpretationResult()).listenEvent(Subscriber.builder(MeasurementMade.class)
 																  .name("taskCount"))
 										   .triggerChecker(new TaskCountTriggerChecker(this.trigger, object, this.scalingTriggerInterpreter.policy.getTargetGroup()));
@@ -103,7 +101,7 @@ final class StimuliInterpreter extends StimuliSwitch<InterpretationResult> {
 					expectedType.getSimpleName(),
 					this.trigger.getExpectedValue().getClass().getSimpleName()));
 		}
-		
+
 		return (T) this.trigger.getExpectedValue();
 	}
 }

--- a/bundles/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entities/FilterChain.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entities/FilterChain.java
@@ -113,13 +113,17 @@ public class FilterChain {
 			} catch (final Exception e) {
 				this.latestResult = FilterResult.disregard(e);
 			}
-			checkResult();
+			checkResult(this.latestResult);
 		} else {
 			this.iterator = null;
 		}
 	}
 
-	private void checkResult() {
+	/**
+	 * Either makes the {@link FilterChain} proceed to the next filter, or ends the
+	 * chain.
+	 */
+	public void checkResult(final FilterResult result) {
 		if (this.latestResult instanceof final FilterResult.Success success) {
 			this.next(success.nextEvent());
 		} else if (this.latestResult instanceof final FilterResult.Disregard disregard) {

--- a/bundles/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entities/FilterChain.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entities/FilterChain.java
@@ -108,12 +108,11 @@ public class FilterChain {
 		if (this.iterator.hasNext()) {
 			try {
 				final Filter filter = this.iterator.next();
-				LOGGER.debug("Next Filter : " + filter.getClass().getSimpleName());
 				this.latestResult = filter.doProcess(new FilterObjectWrapper(event, state));
 			} catch (final Exception e) {
 				this.latestResult = FilterResult.disregard(e);
 			}
-			checkResult(this.latestResult);
+			checkResult();
 		} else {
 			this.iterator = null;
 		}
@@ -123,7 +122,7 @@ public class FilterChain {
 	 * Either makes the {@link FilterChain} proceed to the next filter, or ends the
 	 * chain.
 	 */
-	public void checkResult(final FilterResult result) {
+	public void checkResult() {
 		if (this.latestResult instanceof final FilterResult.Success success) {
 			this.next(success.nextEvent());
 		} else if (this.latestResult instanceof final FilterResult.Disregard disregard) {

--- a/bundles/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entities/LogicalORCompoundFilter.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entities/LogicalORCompoundFilter.java
@@ -1,65 +1,37 @@
 package org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entities;
 
-import org.apache.log4j.Logger;
+import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entities.FilterResult.Disregard;
 import org.palladiosimulator.analyzer.slingshot.common.events.DESEvent;
 
 /**
  *
- * TODO
+ * A CompoundFilter that connects all filters of the chain with an OR.
+ *
+ * Thus, this filter only results in a {@link Disregard} if all parts of the
+ * chain result in a {@link Disregard}.
  *
  * @author Julijan Katic, Sarah Stieß
  *
  */
 public class LogicalORCompoundFilter extends ComboundFilter {
 
-	private static final Logger LOGGER = Logger.getLogger(LogicalORCompoundFilter.class);
-
 	private DESEvent eventToProcess;
 	private int numberDisregarded;
 
-	private FilterObjectWrapper wrapper;
-
-	private FilterResult latestResult;
-
-	private String nesteDisregardMessage;
-
 	@Override
 	public FilterResult doProcess(final FilterObjectWrapper event) {
-
-		this.wrapper = event;
-
-		latestResult = null;
-
 		this.eventToProcess = event.getEventToFilter();
 		this.numberDisregarded = 0;
 		this.next(event.getEventToFilter());
 		this.reset();
-		return latestResult;
+		return this.getLatestResult();
 	}
 
 	@Override
-	public void next(final DESEvent event) {
-		if (!this.filterIsBeingUsed()) {
-			this.iterator = this.filters.iterator();
-		}
-		if (this.iterator.hasNext()) {
-			try {
-				final Filter filter = this.iterator.next();
-				LOGGER.debug("Next Filter : " + filter.getClass().getSimpleName());
-				this.latestResult = filter.doProcess(wrapper);
-			} catch (final Exception e) {
-				this.latestResult = FilterResult.disregard(e);
-			}
-			checkResult();
-		} else {
-			this.iterator = null;
-		}
-	}
-
-	private void checkResult() {
-		if (this.latestResult instanceof final FilterResult.Success success) {
+	public void checkResult(final FilterResult result) {
+		if (result instanceof final FilterResult.Success success) {
 			return; // short circuit
-		} else if (this.latestResult instanceof final FilterResult.Disregard disregard) {
+		} else if (result instanceof final FilterResult.Disregard disregard) {
 			this.disregard(disregard.reason().toString());
 		}
 	}
@@ -68,10 +40,9 @@ public class LogicalORCompoundFilter extends ComboundFilter {
 	public void disregard(final Object message) {
 		this.numberDisregarded++;
 		if (this.numberDisregarded < this.size()) {
-			this.nesteDisregardMessage = (String) message;
 			this.next(this.eventToProcess);
 		} else {
-			this.latestResult = FilterResult.disregard(this.nesteDisregardMessage + " AND " + (String) message);
+			super.disregard(message); // TODO : it would be nice to concatenate the messages.
 		}
 	}
 

--- a/bundles/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entities/LogicalORCompoundFilter.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entities/LogicalORCompoundFilter.java
@@ -1,45 +1,82 @@
 package org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entities;
 
+import org.apache.log4j.Logger;
 import org.palladiosimulator.analyzer.slingshot.common.events.DESEvent;
 
+/**
+ *
+ * TODO
+ *
+ * @author Julijan Katic, Sarah Stieß
+ *
+ */
 public class LogicalORCompoundFilter extends ComboundFilter {
 
-	private FilterResult result = null;
+	private static final Logger LOGGER = Logger.getLogger(LogicalORCompoundFilter.class);
+
 	private DESEvent eventToProcess;
 	private int numberDisregarded;
 
+	private FilterObjectWrapper wrapper;
+
+	private FilterResult latestResult;
+
+	private String nesteDisregardMessage;
+
 	@Override
 	public FilterResult doProcess(final FilterObjectWrapper event) {
-		result = null;
+
+		this.wrapper = event;
+
+		latestResult = null;
+
 		this.eventToProcess = event.getEventToFilter();
 		this.numberDisregarded = 0;
 		this.next(event.getEventToFilter());
-		return result;
+		this.reset();
+		return latestResult;
 	}
 
 	@Override
 	public void next(final DESEvent event) {
-		/* The whole filter was successful, delegate to parent */
-		//this.currentParentChain.next(event);
+		if (!this.filterIsBeingUsed()) {
+			this.iterator = this.filters.iterator();
+		}
+		if (this.iterator.hasNext()) {
+			try {
+				final Filter filter = this.iterator.next();
+				LOGGER.debug("Next Filter : " + filter.getClass().getSimpleName());
+				this.latestResult = filter.doProcess(wrapper);
+			} catch (final Exception e) {
+				this.latestResult = FilterResult.disregard(e);
+			}
+			checkResult();
+		} else {
+			this.iterator = null;
+		}
+	}
 
-		/* Reinitialize */
-		this.initialize();
+	private void checkResult() {
+		if (this.latestResult instanceof final FilterResult.Success success) {
+			return; // short circuit
+		} else if (this.latestResult instanceof final FilterResult.Disregard disregard) {
+			this.disregard(disregard.reason().toString());
+		}
 	}
 
 	@Override
 	public void disregard(final Object message) {
 		this.numberDisregarded++;
 		if (this.numberDisregarded < this.size()) {
-			super.next(this.eventToProcess);
+			this.nesteDisregardMessage = (String) message;
+			this.next(this.eventToProcess);
 		} else {
-		//	this.currentParentChain.disregard(message);
-			this.initialize();
+			this.latestResult = FilterResult.disregard(this.nesteDisregardMessage + " AND " + (String) message);
 		}
-
 	}
 
-	private void initialize() {
-	//	this.currentParentChain = null;
+	private void reset() {
+		this.iterator = null;
 		this.eventToProcess = null;
 		this.numberDisregarded = 0;
 	}

--- a/bundles/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entities/LogicalORCompoundFilter.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entities/LogicalORCompoundFilter.java
@@ -28,10 +28,10 @@ public class LogicalORCompoundFilter extends ComboundFilter {
 	}
 
 	@Override
-	public void checkResult(final FilterResult result) {
-		if (result instanceof final FilterResult.Success success) {
+	public void checkResult() {
+		if (this.getLatestResult() instanceof final FilterResult.Success success) {
 			return; // short circuit
-		} else if (result instanceof final FilterResult.Disregard disregard) {
+		} else if (this.getLatestResult() instanceof final FilterResult.Disregard disregard) {
 			this.disregard(disregard.reason().toString());
 		}
 	}

--- a/bundles/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entities/SPDAdjustorContext.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entities/SPDAdjustorContext.java
@@ -36,7 +36,6 @@ import org.palladiosimulator.spd.triggers.ScalingTrigger;
  * @author Julijan Katic, Sarah Stieß
  */
 public final class SPDAdjustorContext {
-
 	private static final Logger LOGGER = Logger.getLogger(SPDAdjustorContext.class);
 
 	private final FilterChain filterChain;


### PR DESCRIPTION
## Current behaviour

Compound Or filter still did not work. There are two problems:

1. [**UPDATE: Already fixed in #46, no longer part of this PR.**] Duplicated Subscribers in case of CompoundTriggers, that trigger on the same Stimulus, e.g. we define this: 
![image](https://github.com/user-attachments/assets/208f9976-1132-46bf-a6c4-9f5f5ff7a6d3)
and as a result get two subscribers that both listen to `SimulationTimeReached` such that the filter chain processes each `SimulationTimeReached` event twice. 

2. The logical OR is not implemented. The class exists (c.f. `LogicalORCompoundFilter`) but its operation `next` does nothing and the OR filter returns `null` as result.

### Effect of 1. and 2.:

Assume we publish some `SimulationTimeReached` event $e$

The filterchain receives $e$ the first time. due to 2., the OR filter returns `null`, which matches neithers as "success" nor as "dissregard". We do  not publish any events as result, but we do not reset the filter chain either. 
The reset would either happen at the end of the chain (which we do not reach) or on the first disregard (which does not happen either).

Then, due to 1. we receive $e$ for the second time. 
When processing $e$, we do not start at the beginning of the filter chain, but -- as we did not reset it before -- continue processing at the next filter *after* the OR filter.  

## New Behaviour
### Regarding 1 -- **UPDATE: Already fixed in #46, no longer part of this PR.** . 
All subscribers of a filter chain are saved in a `Set` instead of a `List`. After https://github.com/PalladioSimulator/Palladio-Analyzer-Slingshot/pull/15 the equal subscribers are recognized as such, and duplicates are eliminated. No more duplicated receptions. 

### Regarding 2. 
**Mindset**: a `CompoundFilter` is also a `FilterChain`  i.e when using compound triggers, we get tiny filter chains inside our topmost filterchain, which consist of targetgroup checker, trigger checker, constraint checker etc.
Thus, we must/can rely on the filter operations `next` and `disregard` to realize the OR and AND filters. 

For the compound OR filter, we don't really care about `next`, the implementation of the parent class is fine.

However, the parent classes implementation of `checkResult` does not work for OR filters. 
If the result of a filter is *success* the chain continues, if the result of filter is *disregard* the result of the entire chain is *disregard*, which is the exact opposite of what must happen for an OR filter. 
Thus, the overwrite of `checkResult` and `disregard`.

On a closer look, it should suffice to overwrite `disregard`, but then the filter cannot shortcircuit. 
On an even close look, we must overwrite `checkResult` as well, because if get into disregard for the last part of the OR, we cannot change the outcome any more.

## Misc
Depends on https://github.com/PalladioSimulator/Palladio-Analyzer-Slingshot/pull/15