### PR TITLE
Emitting of Allocation Changes

### DIFF
--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd.adjustment/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/adjustment/SpdAdjustmentBehavior.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd.adjustment/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/adjustment/SpdAdjustmentBehavior.java
@@ -27,15 +27,12 @@ import org.palladiosimulator.analyzer.slingshot.eventdriver.returntypes.Result;
 import org.palladiosimulator.monitorrepository.MonitorRepository;
 import org.palladiosimulator.pcm.allocation.Allocation;
 import org.palladiosimulator.pcm.allocation.AllocationContext;
-import org.palladiosimulator.pcm.core.composition.AssemblyConnector;
-import org.palladiosimulator.pcm.core.composition.AssemblyContext;
 import org.palladiosimulator.pcm.resourceenvironment.ResourceContainer;
 import org.palladiosimulator.pcm.resourceenvironment.ResourceEnvironment;
 import org.palladiosimulator.semanticspd.Configuration;
 import org.palladiosimulator.semanticspd.ElasticInfrastructureCfg;
 import org.palladiosimulator.semanticspd.SemanticspdFactory;
 import org.palladiosimulator.spd.SPD;
-import org.palladiosimulator.spd.targets.ElasticInfrastructure;
 
 @OnEvent(when = ModelAdjustmentRequested.class, then = ModelAdjusted.class, cardinality = EventCardinality.SINGLE)
 public class SpdAdjustmentBehavior implements SimulationBehaviorExtension {
@@ -98,27 +95,27 @@ public class SpdAdjustmentBehavior implements SimulationBehaviorExtension {
 			 */
 			final List<ResourceContainer> newResourceContainers = new ArrayList<>(environment.getResourceContainer_ResourceEnvironment());
 			newResourceContainers.removeAll(oldContainers);
-			
+
 			final List<ResourceContainer> deletedResourceContainers = new ArrayList<>(oldContainers);
 			deletedResourceContainers.removeAll(environment.getResourceContainer_ResourceEnvironment());
-			
-			
+
+
 			final List<AllocationContext> newAllocationContexts =  new ArrayList<>(allocation.getAllocationContexts_Allocation());
 			newAllocationContexts.removeAll(oldAllocationContexts);
-			
-			
+
+
 			final List<ModelChange<?>> changes = new ArrayList<>();
 
-			
-			
+
+
 			changes.add(ResourceEnvironmentChange.builder()
 					.resourceEnvironment(environment).simulationTime(event.time()).oldResourceContainers(oldContainers)
 					.newResourceContainers(newResourceContainers).deletedResourceContainers(deletedResourceContainers)
 					.build());
-			
-			
+
+
 			changes.add(AllocationChange.builder().allocation(allocation).newAllocationContexts(newAllocationContexts).build());
-			
+
 
 			changes.addAll(this.createMonitors(newResourceContainers, event.time()));
 

--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd.data/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/data/adjustment/AllocationChange.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd.data/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/data/adjustment/AllocationChange.java
@@ -2,17 +2,16 @@ package org.palladiosimulator.analyzer.slingshot.behavior.spd.data.adjustment;
 
 import java.util.List;
 
-import org.palladiosimulator.analyzer.slingshot.behavior.spd.data.adjustment.ResourceEnvironmentChange.Builder;
 import org.palladiosimulator.pcm.allocation.Allocation;
 import org.palladiosimulator.pcm.allocation.AllocationContext;
 
 public class AllocationChange extends ModelChange<Allocation> {
-	
-	private List<AllocationContext> newAllocationContexts;
+
+	private final List<AllocationContext> newAllocationContexts;
 	private double simulationTime;
 
     // Private constructor to enforce the use of the builder
-    private AllocationChange(Builder builder) {
+    private AllocationChange(final Builder builder) {
         super(builder.allocation, builder.simulationTime);
         this.newAllocationContexts = builder.newAllocationContexts;
     }
@@ -24,25 +23,25 @@ public class AllocationChange extends ModelChange<Allocation> {
 	public static Builder builder() {
 		return new Builder();
 	}
-    
+
 	// Builder class for AllocationChange
     public static class Builder {
 
     	private Allocation allocation;
         private List<AllocationContext> newAllocationContexts;
     	private double simulationTime = -1;
-    	
-    	
+
+
 		public Builder allocation(final Allocation allocation) {
 			this.allocation = allocation;
 			return this;
 		}
-    	
-        public Builder newAllocationContexts(List<AllocationContext> newAllocationContexts) {
+
+        public Builder newAllocationContexts(final List<AllocationContext> newAllocationContexts) {
             this.newAllocationContexts = newAllocationContexts;
             return this;
         }
-        
+
 		public Builder simulationTime(final double simulationTime) {
 			this.simulationTime = simulationTime;
 			return this;
@@ -52,6 +51,6 @@ public class AllocationChange extends ModelChange<Allocation> {
             return new AllocationChange(this);
         }
     }
-	
+
 
 }

--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd.data/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/data/adjustment/AllocationChange.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd.data/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/data/adjustment/AllocationChange.java
@@ -1,0 +1,57 @@
+package org.palladiosimulator.analyzer.slingshot.behavior.spd.data.adjustment;
+
+import java.util.List;
+
+import org.palladiosimulator.analyzer.slingshot.behavior.spd.data.adjustment.ResourceEnvironmentChange.Builder;
+import org.palladiosimulator.pcm.allocation.Allocation;
+import org.palladiosimulator.pcm.allocation.AllocationContext;
+
+public class AllocationChange extends ModelChange<Allocation> {
+	
+	private List<AllocationContext> newAllocationContexts;
+	private double simulationTime;
+
+    // Private constructor to enforce the use of the builder
+    private AllocationChange(Builder builder) {
+        super(builder.allocation, builder.simulationTime);
+        this.newAllocationContexts = builder.newAllocationContexts;
+    }
+
+    public List<AllocationContext> getNewAllocationContexts() {
+        return newAllocationContexts;
+    }
+
+	public static Builder builder() {
+		return new Builder();
+	}
+    
+	// Builder class for AllocationChange
+    public static class Builder {
+
+    	private Allocation allocation;
+        private List<AllocationContext> newAllocationContexts;
+    	private double simulationTime = -1;
+    	
+    	
+		public Builder allocation(final Allocation allocation) {
+			this.allocation = allocation;
+			return this;
+		}
+    	
+        public Builder newAllocationContexts(List<AllocationContext> newAllocationContexts) {
+            this.newAllocationContexts = newAllocationContexts;
+            return this;
+        }
+        
+		public Builder simulationTime(final double simulationTime) {
+			this.simulationTime = simulationTime;
+			return this;
+		}
+
+        public AllocationChange build() {
+            return new AllocationChange(this);
+        }
+    }
+	
+
+}


### PR DESCRIPTION
Simply tells which allocations are created after the adjustment. Neccessary to implement https://github.com/PalladioSimulator/Palladio-Analyzer-Slingshot-Extension-PCM-Core/pull/52