### PR TITLE
Bug fix: checking measurements source correctly

### DIFF
--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/utils/TargetGroupUtils.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/utils/TargetGroupUtils.java
@@ -1,8 +1,9 @@
 package org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.utils;
 
+import java.util.List;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
 import org.palladiosimulator.analyzer.slingshot.core.Slingshot;
 import org.palladiosimulator.pcm.allocation.Allocation;
 import org.palladiosimulator.pcm.allocation.AllocationContext;
@@ -12,7 +13,9 @@ import org.palladiosimulator.pcm.repository.OperationSignature;
 import org.palladiosimulator.pcm.resourceenvironment.ResourceContainer;
 import org.palladiosimulator.semanticspd.CompetingConsumersGroupCfg;
 import org.palladiosimulator.semanticspd.Configuration;
+import org.palladiosimulator.semanticspd.ElasticInfrastructureCfg;
 import org.palladiosimulator.semanticspd.ServiceGroupCfg;
+import org.palladiosimulator.semanticspd.TargetGroupCfg;
 import org.palladiosimulator.spd.targets.CompetingConsumersGroup;
 import org.palladiosimulator.spd.targets.ElasticInfrastructure;
 import org.palladiosimulator.spd.targets.ServiceGroup;
@@ -39,10 +42,22 @@ public class TargetGroupUtils {
 	 * @return true iff the container is part of the environment.
 	 */
 	public static boolean isContainerInElasticInfrastructure(final ResourceContainer container, final ElasticInfrastructure targetGroup) {
-		return targetGroup.getPCM_ResourceEnvironment()
-						  .getResourceContainer_ResourceEnvironment()
-						  .stream()
-						  .anyMatch(rc -> rc.getId().equals(container.getId()));
+		
+		List<ElasticInfrastructureCfg> elasticInfraCfgs = configuration.getTargetCfgs().stream()
+														  .filter(cfg->cfg instanceof ElasticInfrastructureCfg c)
+														  .map(c -> (ElasticInfrastructureCfg)c)
+														  .filter(c -> c.getUnit().getId().equals(targetGroup.getUnit().getId()))
+														  .collect(Collectors.toList());
+		
+		assert elasticInfraCfgs.size() == 1;
+		
+		return elasticInfraCfgs.get(0).getElements().stream().anyMatch(rc -> rc.getId().equals(container.getId()));
+														  
+		
+//		return targetGroup.getPCM_ResourceEnvironment()
+//						  .getResourceContainer_ResourceEnvironment()
+//						  .stream()
+//						  .anyMatch(rc -> rc.getId().equals(container.getId()));
 	}
 	
 	/**

--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/utils/TargetGroupUtils.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/utils/TargetGroupUtils.java
@@ -52,12 +52,7 @@ public class TargetGroupUtils {
 		assert elasticInfraCfgs.size() == 1;
 		
 		return elasticInfraCfgs.get(0).getElements().stream().anyMatch(rc -> rc.getId().equals(container.getId()));
-														  
-		
-//		return targetGroup.getPCM_ResourceEnvironment()
-//						  .getResourceContainer_ResourceEnvironment()
-//						  .stream()
-//						  .anyMatch(rc -> rc.getId().equals(container.getId()));
+												
 	}
 	
 	/**


### PR DESCRIPTION
Behavior before:

The check whether the measurement are sourcing from resource container part of the elastic infrastructure was wrongly implemented: the check did only check whether the resource container is part of the resource environment.

New Behavior:

Checks whether the resource container is part of the Elastic Infrastructure Configuration.

