### PR TITLE
Thrashing Constraints

### DIFF
--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entities/SPDAdjustorState.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entities/SPDAdjustorState.java
@@ -2,11 +2,18 @@ package org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entiti
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+
+import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.utils.MeasuringPointInsideTargetGroup;
+import org.palladiosimulator.spd.ScalingPolicy;
+import org.palladiosimulator.spd.targets.TargetGroup;
 
 /**
  * This class holds the state for each scaling policy definition.
  * The state include information about when the latest adjustment
  * has happened, as well as how many scaling has happened.
+ * 
+ * In addition it holds a reference to the target group state.
  * 
  * @author Julijan Katic, Floriment Klinaku
  */
@@ -15,16 +22,30 @@ public final class SPDAdjustorState {
 	private double latestAdjustmentAtSimulationTime = 0;
 	private int numberScales = 0;
 	
+	// Reference to the targetGroupState
+	private final TargetGroupState targetGroupState;
+	private final ScalingPolicy scalingPolicy;
+	
 	// state for evaluating cooldown constraints
 	private double coolDownEnd = 0;
 	private int numberOfScalesInCooldown = 0;
 	
+	
+	public SPDAdjustorState(final ScalingPolicy scalingPolicy, final TargetGroupState targetGroupState) {
+		this.scalingPolicy = Objects.requireNonNull(scalingPolicy);
+		this.targetGroupState = Objects.requireNonNull(targetGroupState);
+	}
+
 	public double getLatestAdjustmentAtSimulationTime() {
 		return latestAdjustmentAtSimulationTime;
 	}
 
 	public void setLatestAdjustmentAtSimulationTime(double latestAdjustmentAtSimulationTime) {
 		this.latestAdjustmentAtSimulationTime = latestAdjustmentAtSimulationTime;
+	}
+	
+	public TargetGroupState getTargetGroupState() {
+		return targetGroupState;
 	}
 	
 	public void incrementNumberScales() {
@@ -53,6 +74,10 @@ public final class SPDAdjustorState {
 	
 	public void incrementNumberOfAdjustmentsInCooldown() {
 		this.numberOfScalesInCooldown++;
+	}
+
+	public ScalingPolicy getScalingPolicy() {
+		return scalingPolicy;
 	}
 	
 }

--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entities/TargetGroupState.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entities/TargetGroupState.java
@@ -1,0 +1,50 @@
+package org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entities;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.palladiosimulator.spd.ScalingPolicy;
+import org.palladiosimulator.spd.targets.TargetGroup;
+
+import com.google.common.collect.Iterables;
+
+public class TargetGroupState {
+
+	// state of 
+	private final TargetGroup targetGroup;
+	
+	
+	private final List<Double> enactmentTimeOfScalingPolicies = new ArrayList<>();
+	private final List<ScalingPolicy> enactedScalingPolicies = new ArrayList<>() ;
+	
+	public TargetGroupState(final TargetGroup target) {
+		this.targetGroup = target;
+	}
+	
+	public TargetGroup getTargetGroup() {
+		return targetGroup;
+	}
+	
+	public void addEnactedPolicy(double simulationTime, ScalingPolicy enactedPolicy) {
+		enactmentTimeOfScalingPolicies.add(simulationTime);
+		enactedScalingPolicies.add(enactedPolicy);
+	}
+	
+	public double getLastScalingPolicyEnactmentTime() {
+		return Iterables.getLast(enactmentTimeOfScalingPolicies);
+	}
+	
+	public ScalingPolicy getLastEnactedScalingPolicy() {
+		return Iterables.getLast(enactedScalingPolicies);
+	}
+	
+	public boolean enactedPoliciesEmpty() {
+		return Iterables.isEmpty(enactedScalingPolicies);
+	}
+	
+	
+	
+	
+	
+}

--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/adjustor/Adjustor.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/adjustor/Adjustor.java
@@ -33,6 +33,9 @@ public class Adjustor implements Filter {
 				objectWrapper.getEventToFilter().time());
 		objectWrapper.getState().incrementNumberScales();
 
+		
+		objectWrapper.getState().getTargetGroupState().addEnactedPolicy(currentSimTime, policy);
+		
 		Optional<CooldownConstraint> cooldownConstraint = policy.getPolicyConstraints().stream()
                 .filter(obj -> obj instanceof CooldownConstraint)
                 .map(obj -> (CooldownConstraint) obj).findAny();

--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/constraint/AbstractConstraintFilter.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/constraint/AbstractConstraintFilter.java
@@ -4,6 +4,7 @@ import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entitie
 import org.palladiosimulator.spd.constraints.AbstractConstraint;
 import org.palladiosimulator.spd.constraints.policy.CooldownConstraint;
 import org.palladiosimulator.spd.constraints.policy.IntervalConstraint;
+import org.palladiosimulator.spd.constraints.target.ThrashingConstraint;
 
 /**
  * Defines accordingly to {@link PolicyConstraint} or {@link TargetConstraint} whether
@@ -24,7 +25,10 @@ public abstract class AbstractConstraintFilter<T extends AbstractConstraint> imp
 			return new CooldownConstraintFilter(cooldownConstraint);
 		} else if (constraint instanceof final IntervalConstraint intervallConstraint) {
 			return new IntervalConstraintFilter(intervallConstraint);
-		} else {
+		} else if (constraint instanceof final ThrashingConstraint thrashingConstraint) {
+			return new ThrashingConstraintFilter(thrashingConstraint);
+		}
+		else {
 			throw new UnsupportedOperationException("Currently, only cooldown and intervall is supported");
 		}
 	}

--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/constraint/ThrashingConstraintFilter.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/constraint/ThrashingConstraintFilter.java
@@ -1,0 +1,79 @@
+/**
+ * 
+ */
+package org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entity.constraint;
+
+import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entities.FilterObjectWrapper;
+import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entities.FilterResult;
+import org.palladiosimulator.analyzer.slingshot.behavior.spd.interpreter.entities.TargetGroupState;
+import org.palladiosimulator.spd.ScalingPolicy;
+import org.palladiosimulator.spd.adjustments.AbsoluteAdjustment;
+import org.palladiosimulator.spd.adjustments.AdjustmentType;
+import org.palladiosimulator.spd.adjustments.RelativeAdjustment;
+import org.palladiosimulator.spd.adjustments.StepAdjustment;
+import org.palladiosimulator.spd.constraints.target.ThrashingConstraint;
+
+/**
+ * The thrashing constraint filter makes sure that there is a certain amount of
+ * time passed since the last enacted policy that adjusted the amount of
+ * resources in the opposite direction in comparison to the one being enacted.
+ * 
+ * @author Floriment Klinaku
+ *
+ */
+public class ThrashingConstraintFilter extends AbstractConstraintFilter<ThrashingConstraint> {
+
+	private enum ADJUSTMENT_SIGN {
+		POSITIVE,
+		NEGATIVE
+	}
+	
+	
+	public ThrashingConstraintFilter(ThrashingConstraint constraint) {
+		super(constraint);
+		// TODO Auto-generated constructor stub
+	}
+
+	@Override
+	public FilterResult doProcess(FilterObjectWrapper event) {
+			
+		TargetGroupState targetGroupState = event.getState().getTargetGroupState();
+		
+		if(targetGroupState.enactedPoliciesEmpty()) {
+			//no previously executed policies, thrashing passes
+			return FilterResult.success(event.getEventToFilter());
+		}
+		
+		ScalingPolicy lastEnactedPolicy = targetGroupState.getLastEnactedScalingPolicy();
+		double lastSimulationTime = targetGroupState.getLastScalingPolicyEnactmentTime();
+		double currentSimulationTime = event.getEventToFilter().time();
+		
+		ScalingPolicy currentScalingPolicy = event.getState().getScalingPolicy();
+		
+		if(currentScalingPolicy.getAdjustmentType() instanceof AbsoluteAdjustment
+				|| lastEnactedPolicy.getAdjustmentType() instanceof AbsoluteAdjustment) {
+			return FilterResult.success(event.getEventToFilter());
+		}
+	
+		if(!retrieveSign(currentScalingPolicy.getAdjustmentType()).equals(retrieveSign(lastEnactedPolicy.getAdjustmentType()))
+				&& lastSimulationTime+constraint.getMinimumTimeNoThrashing()>=currentSimulationTime
+				)
+		{
+			// opposite signs and min time did not pass -> disregard
+			return FilterResult.disregard(event.getEventToFilter());
+		}
+		return FilterResult.success(event.getEventToFilter());
+	}
+	
+	
+	
+	public ADJUSTMENT_SIGN retrieveSign(AdjustmentType adjustmentType) {
+		if(adjustmentType instanceof final RelativeAdjustment relativeAdjustment) {
+			return relativeAdjustment.getPercentageGrowthValue()>0?ADJUSTMENT_SIGN.POSITIVE:ADJUSTMENT_SIGN.NEGATIVE;
+		} else if(adjustmentType instanceof final StepAdjustment stepAdjustment) {
+			return stepAdjustment.getStepValue()>0?ADJUSTMENT_SIGN.POSITIVE:ADJUSTMENT_SIGN.NEGATIVE;
+		} 
+		return ADJUSTMENT_SIGN.POSITIVE;
+	}
+
+}


### PR DESCRIPTION
### Before

The feature of thrashing constraint was not present.

### Changes

Since there is a filter chain for each SP that checks the triggering and associated constraints and finally calls the adjustment, it was necessary to create a set of TargetGroupState objects beforehand and pass the reference to the corresponding TargetGroupState to each filter chain. This way, each filter chain can contribute to the overall TargetGroupState, which mainly is the notification that a policy is enacted and the simulation time when this is enacted. This information then is used in a ThrashingConstraintFilter. 
