### PR TITLE
Indexed access in `QVToCache`

### DIFF
--- a/org.palladiosimulator.analyzer.slingshot.behavior.spd.adjustment/META-INF/MANIFEST.MF
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.spd.adjustment/META-INF/MANIFEST.MF
@@ -22,5 +22,7 @@ Require-Bundle: org.palladiosimulator.analyzer.slingshot.behavior.spd.data;bundl
  org.palladiosimulator.spd.semantic.transformations;bundle-version="1.0.0",
  org.palladiosimulator.spd.semantic;bundle-version="1.0.0",
  org.palladiosimulator.analyzer.slingshot.ui.events;bundle-version="1.0.0",
- org.palladiosimulator.analyzer.slingshot.workflow.events;bundle-version="1.0.0"
+ org.palladiosimulator.analyzer.slingshot.workflow.events;bundle-version="1.0.0",
+ org.modelversioning.emfprofile,
+ org.eclipse.gmf.runtime.notation;bundle-version="1.10.0"
 Export-Package: org.palladiosimulator.analyzer.slingshot.behavior.spd.monitor


### PR DESCRIPTION
## Current
In `QVToCache` model from a resource are accessed with a hardcoded `contents.get(0)`. 
This works in most cases, but caused probems when i played around with a Stereotypes (e.g. AT, cost), a the Stereotype application Model is a distinct model saved in the same resource as the model it applies to. 

## New
* Faltmap to get not only the first model of each resource, but all. 
* Use blacklist, to explicitly remove stereotype application models and GMF things. 