### PR TITLE
remove fixed version numbers on dependencies to other slingshot components

### DIFF
--- a/bundles/org.palladiosimulator.analyzer.slingshot.behavior.spd.adjustment/META-INF/MANIFEST.MF
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.behavior.spd.adjustment/META-INF/MANIFEST.MF
@@ -5,14 +5,14 @@ Bundle-SymbolicName: org.palladiosimulator.analyzer.slingshot.behavior.spd.adjus
 Bundle-Version: 1.0.0.qualifier
 Automatic-Module-Name: org.palladiosimulator.analyzer.slingshot.behavior.spd.adjustment
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Require-Bundle: org.palladiosimulator.analyzer.slingshot.behavior.spd.data;bundle-version="1.0.0",
- org.palladiosimulator.analyzer.slingshot.core;bundle-version="1.0.0",
+Require-Bundle: org.palladiosimulator.analyzer.slingshot.behavior.spd.data,
+ org.palladiosimulator.analyzer.slingshot.core,
  org.palladiosimulator.monitorrepository,
  org.palladiosimulator.pcm.edp2.measuringpoint,
  org.eclipse.m2m.qvt.oml;bundle-version="3.10.4",
  de.uka.ipd.sdq.workflow.mdsd.blackboard,
  org.palladiosimulator.analyzer.workflow,
- org.palladiosimulator.spd.semantic;bundle-version="1.0.0",
- org.palladiosimulator.analyzer.slingshot.ui.events;bundle-version="1.0.0",
- org.palladiosimulator.analyzer.slingshot.workflow.events;bundle-version="1.0.0"
+ org.palladiosimulator.spd.semantic,
+ org.palladiosimulator.analyzer.slingshot.ui.events,
+ org.palladiosimulator.analyzer.slingshot.workflow.events
 Export-Package: org.palladiosimulator.analyzer.slingshot.behavior.spd.monitor

--- a/bundles/org.palladiosimulator.analyzer.slingshot.behavior.spd.data/META-INF/MANIFEST.MF
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.behavior.spd.data/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.palladiosimulator.analyzer.slingshot.behavior.spd.data
 Bundle-Version: 1.0.0.qualifier
 Automatic-Module-Name: org.palladiosimulator.analyzer.slingshot.behavior.spd.data
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Require-Bundle: org.palladiosimulator.analyzer.slingshot.common;bundle-version="1.0.0",
+Require-Bundle: org.palladiosimulator.analyzer.slingshot.common,
  org.palladiosimulator.spd,
  org.palladiosimulator.monitorrepository
 Export-Package: org.palladiosimulator.analyzer.slingshot.behavior.spd.data

--- a/bundles/org.palladiosimulator.analyzer.slingshot.behavior.spd/META-INF/MANIFEST.MF
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.behavior.spd/META-INF/MANIFEST.MF
@@ -5,12 +5,12 @@ Bundle-SymbolicName: org.palladiosimulator.analyzer.slingshot.behavior.spd;singl
 Bundle-Version: 1.0.0.qualifier
 Automatic-Module-Name: org.palladiosimulator.analyzer.slingshot.behavior.spd
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Require-Bundle: org.palladiosimulator.analyzer.slingshot.core;bundle-version="1.0.0",
- org.palladiosimulator.analyzer.slingshot.monitor.data;bundle-version="1.0.0",
+Require-Bundle: org.palladiosimulator.analyzer.slingshot.core,
+ org.palladiosimulator.analyzer.slingshot.monitor.data,
  org.palladiosimulator.analyzer.slingshot.behavior.spd.data,
  de.uka.ipd.sdq.workflow.mdsd.blackboard;bundle-version="5.1.0",
  org.palladiosimulator.analyzer.workflow;bundle-version="5.1.0",
- org.palladiosimulator.analyzer.slingshot.ui.events;bundle-version="1.0.0",
- org.palladiosimulator.analyzer.slingshot.workflow.events;bundle-version="1.0.0",
+ org.palladiosimulator.analyzer.slingshot.ui.events,
+ org.palladiosimulator.analyzer.slingshot.workflow.events,
  org.palladiosimulator.pcm.edp2.measuringpoint,
  org.palladiosimulator.spd.semantic


### PR DESCRIPTION
For some dependencies to other Slingshot components, their verison was fixed to `1.0.0`.

When attempting to export and installable feature from the slingshot, and installing the feature, this cause an error because of missing depenencies / mismatched dependencie versions.

I now removed all fixed versions that caused problems. For my, export an installation works now.

(Edit: duplicated of rejected PR, where i branched off the wrong branch.)