### PR TITLE
improve disregard messages.

### DIFF
--- a/bundles/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/constraint/ThrashingConstraintFilter.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/constraint/ThrashingConstraintFilter.java
@@ -58,7 +58,7 @@ public final class ThrashingConstraintFilter extends AbstractConstraintFilter<Th
 		if(!retrieveSign(currentScalingPolicy.getAdjustmentType()).equals(retrieveSign(lastEnactedPolicy.getAdjustmentType()))
 				&& lastSimulationTime + constraint.getMinimumTimeNoThrashing() >= currentSimulationTime) {
 			// opposite signs and min time did not pass -> disregard
-			return FilterResult.disregard(event.getEventToFilter());
+			return FilterResult.disregard("Thrashing Constraint prevents this scaling Operation.");
 		}
 		return FilterResult.success(event.getEventToFilter());
 	}

--- a/bundles/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/targetgroup/TargetGroupChecker.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/targetgroup/TargetGroupChecker.java
@@ -28,7 +28,7 @@ public class TargetGroupChecker implements Filter {
 			if (this.measuringPointInsideTargetGroupSwitch.doSwitch(mm.getEntity().getMeasuringPoint())) {
 				return FilterResult.success(event);
 			}
-			return FilterResult.disregard("The measurement is not inside this target group");
+			return FilterResult.disregard("The measurement is not inside this target group. Expected measurement for " + targetGroup.getEntityName() + " but received measurement for " + mm.getEntity().getMeasuringPoint().getStringRepresentation());
 		}
 		if (!(event instanceof SimulationTimeReached)) {
 			return FilterResult.disregard("The event can only be checked if it is a MeasurementMade OR SimulationTimeReached at the moment.");

--- a/bundles/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/trigger/OperationResponseTimeTriggerChecker.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/trigger/OperationResponseTimeTriggerChecker.java
@@ -42,14 +42,17 @@ public final class OperationResponseTimeTriggerChecker extends TriggerChecker<Op
 
 					if (this.compareToTrigger(operationTime) == ComparatorResult.IN_ACCORDANCE) {
 						return FilterResult.success(event);
+					} else {
+						return FilterResult.disregard("Conditions for trigger " + trigger.getId() + " are not met.");
 					}
 				} else {
-					return FilterResult.disregard("The signatures do not match");
+					return FilterResult.disregard("Expected signature " +  thisSignature.getEntityName() + " but received " + referencedSignature.getEntityName());
 				}
+			} else {
+				return FilterResult.disregard("Expected measuringpoint of type " +  OperationReference.class.getSimpleName() + ", but received measuringpoint of type " + point.getClass().getSimpleName());
 			}
+		} else {
+			return FilterResult.disregard("Expected measurement made event, but received " + event.getClass().getSimpleName());
 		}
-		
-		
-		return FilterResult.disregard();
 	}
 }

--- a/bundles/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/trigger/SimulationTimeChecker.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.behavior.spd/src/org/palladiosimulator/analyzer/slingshot/behavior/spd/interpreter/entity/trigger/SimulationTimeChecker.java
@@ -20,7 +20,7 @@ public final class SimulationTimeChecker extends TriggerChecker<SimulationTime> 
 	public FilterResult doProcess(final FilterObjectWrapper objectWrapper) {
 		final DESEvent event = objectWrapper.getEventToFilter();
 		if (!(event instanceof SimulationTimeReached)) {
-			return FilterResult.disregard("");
+			return FilterResult.disregard("Expected simulation time reached event, but received" + event.getClass().getSimpleName());
 		}
 		
 		final SimulationTimeReached simulationTimeReached = (SimulationTimeReached) event;


### PR DESCRIPTION
## Context

We have filterchain for each policy. If any of the filters are not successfull, it returns a `Disregard` with a reason as result. 
Reasons are later on logged to console. 

## Current Behaviour
Some reasons are not helpfull or even missleading.

## New Behaviour
Given reasons are more helpfull.

## Misc
I tried to debug some stuff wrt. constraint filters and got annoyed with the disregard messages, thus this PR. 